### PR TITLE
implement PodsReady and AppWrapper failure detection

### DIFF
--- a/api/v1beta2/appwrapper_types.go
+++ b/api/v1beta2/appwrapper_types.go
@@ -78,6 +78,7 @@ type AppWrapperCondition string
 const (
 	QuotaReserved     AppWrapperCondition = "QuotaReserved"
 	ResourcesDeployed AppWrapperCondition = "ResourcesDeployed"
+	PodsReady         AppWrapperCondition = "PodsReady"
 )
 
 //+kubebuilder:object:root=true

--- a/internal/controller/appwrapper_controller.go
+++ b/internal/controller/appwrapper_controller.go
@@ -181,12 +181,12 @@ func (r *AppWrapperReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		if err != nil {
 			return ctrl.Result{}, err
 		}
-		if podStatus.succeeded >= podStatus.expected {
+		if podStatus.succeeded >= podStatus.expected && (podStatus.pending+podStatus.running == 0) {
 			meta.SetStatusCondition(&aw.Status.Conditions, metav1.Condition{
 				Type:    string(workloadv1beta2.QuotaReserved),
 				Status:  metav1.ConditionFalse,
 				Reason:  string(workloadv1beta2.AppWrapperSucceeded),
-				Message: fmt.Sprintf("%v pods succeeded", podStatus.succeeded),
+				Message: fmt.Sprintf("%v pods succeeded and no running or pending pods", podStatus.succeeded),
 			})
 			return r.updateStatus(ctx, aw, workloadv1beta2.AppWrapperSucceeded)
 		}
@@ -195,8 +195,8 @@ func (r *AppWrapperReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 				Type:   string(workloadv1beta2.PodsReady),
 				Status: metav1.ConditionFalse,
 				Reason: "PodsFailed",
-				Message: fmt.Sprintf("%v pods failed (%v pods running; %v pods succeeded)",
-					podStatus.failed, podStatus.running, podStatus.succeeded),
+				Message: fmt.Sprintf("%v pods failed (%v pods pending; %v pods running; %v pods succeeded)",
+					podStatus.failed, podStatus.pending, podStatus.running, podStatus.succeeded),
 			})
 			return r.updateStatus(ctx, aw, workloadv1beta2.AppWrapperFailed)
 		}

--- a/internal/controller/appwrapper_controller.go
+++ b/internal/controller/appwrapper_controller.go
@@ -181,12 +181,12 @@ func (r *AppWrapperReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		if err != nil {
 			return ctrl.Result{}, err
 		}
-		if podStatus.succeeded >= podStatus.expected && (podStatus.pending+podStatus.running == 0) {
+		if podStatus.succeeded >= podStatus.expected && (podStatus.pending+podStatus.running+podStatus.failed == 0) {
 			meta.SetStatusCondition(&aw.Status.Conditions, metav1.Condition{
 				Type:    string(workloadv1beta2.QuotaReserved),
 				Status:  metav1.ConditionFalse,
 				Reason:  string(workloadv1beta2.AppWrapperSucceeded),
-				Message: fmt.Sprintf("%v pods succeeded and no running or pending pods", podStatus.succeeded),
+				Message: fmt.Sprintf("%v pods succeeded and no running, pending, or failed pods", podStatus.succeeded),
 			})
 			return r.updateStatus(ctx, aw, workloadv1beta2.AppWrapperSucceeded)
 		}

--- a/internal/controller/workload_controller.go
+++ b/internal/controller/workload_controller.go
@@ -297,5 +297,5 @@ func (aw *AppWrapper) Finished() (metav1.Condition, bool) {
 }
 
 func (aw *AppWrapper) PodsReady() bool {
-	return true // TODO
+	return meta.IsStatusConditionTrue(aw.Status.Conditions, string(workloadv1beta2.PodsReady))
 }

--- a/samples/wrapped-pod.yaml
+++ b/samples/wrapped-pod.yaml
@@ -17,6 +17,10 @@ spec:
         name: sample
       spec:
         restartPolicy: Never
+        initContainers:
+        - name: stall
+          image: quay.io/project-codeflare/busybox:1.36
+          command: ["sh", "-c", "sleep 10"]
         containers:
         - name: busybox
           image: quay.io/project-codeflare/busybox:1.36


### PR DESCRIPTION
1. In the Running phase, periodically gather pod status counts.
2. Set PodsReady condition based on pod status counts.
3. Implement failure detection based on pod status counts.
4. Add init container to wrapped pod sample to demo PodsReady conditions
