### PR TITLE
call SetControllerReference when creating component instances

### DIFF
--- a/internal/controller/appwrapper_controller.go
+++ b/internal/controller/appwrapper_controller.go
@@ -321,6 +321,9 @@ func (r *AppWrapperReconciler) createComponents(ctx context.Context, aw *workloa
 			}
 			return err, meta.IsNoMatchError(err) || apierrors.IsInvalid(err) // fatal
 		}
+		if err := controllerutil.SetControllerReference(aw, obj, r.Scheme); err != nil {
+			return err, true
+		}
 	}
 	return nil, false
 }


### PR DESCRIPTION
This creates the metadata to identify the aw as the controller for each wrapped resource.