### PR TITLE
Propagate admission to child workload objects

### DIFF
--- a/internal/controller/appwrapper_config.go
+++ b/internal/controller/appwrapper_config.go
@@ -22,6 +22,7 @@ import (
 	"os"
 
 	ctrl "sigs.k8s.io/controller-runtime"
+
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 )
 

--- a/internal/controller/appwrapper_controller.go
+++ b/internal/controller/appwrapper_controller.go
@@ -330,6 +330,7 @@ func (r *AppWrapperReconciler) createComponent(ctx context.Context, aw *workload
 	if err != nil {
 		return nil, err, true
 	}
+	obj.SetLabels(utilmaps.MergeKeepFirst(awLabels, obj.GetLabels()))
 
 	for podSetsIdx, podSet := range component.PodSets {
 		toInject := component.PodSetInfos[podSetsIdx]

--- a/internal/controller/appwrapper_controller.go
+++ b/internal/controller/appwrapper_controller.go
@@ -34,7 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	kueueControllerConstants "sigs.k8s.io/kueue/pkg/controller/constants"
+	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/podset"
 	utilmaps "sigs.k8s.io/kueue/pkg/util/maps"
 	"sigs.k8s.io/kueue/pkg/workload"
@@ -327,7 +327,7 @@ func (r *AppWrapperReconciler) createComponent(ctx context.Context, aw *workload
 	if err != nil {
 		return nil, err, true
 	}
-	obj.SetLabels(utilmaps.MergeKeepFirst(obj.GetLabels(), map[string]string{AppWrapperLabel: aw.Name, kueueControllerConstants.QueueLabel: childJobQueueName}))
+	obj.SetLabels(utilmaps.MergeKeepFirst(obj.GetLabels(), map[string]string{AppWrapperLabel: aw.Name, constants.QueueLabel: childJobQueueName}))
 
 	awLabels := map[string]string{AppWrapperLabel: aw.Name}
 	for podSetsIdx, podSet := range component.PodSets {
@@ -427,7 +427,7 @@ func (r *AppWrapperReconciler) propagateAdmission(ctx context.Context, aw *workl
 					workload.SetQuotaReservation(newWorkload, &admission)
 					_ = workload.SyncAdmittedCondition(newWorkload)
 					if err = workload.ApplyAdmissionStatus(ctx, r.Client, newWorkload, false); err != nil {
-						log.FromContext(ctx).Error(err, "syncing admission", "appwrapper", aw, "component", obj, "workload", wl, "newworkload", newWorkload)
+						log.FromContext(ctx).Error(err, "syncing admission", "appwrapper", aw, "componentIdx", componentIdx, "workload", wl, "newworkload", newWorkload)
 					}
 				}
 			}

--- a/internal/controller/appwrapper_controller.go
+++ b/internal/controller/appwrapper_controller.go
@@ -28,19 +28,20 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/pkg/controller/constants"
+	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	"sigs.k8s.io/kueue/pkg/podset"
 	utilmaps "sigs.k8s.io/kueue/pkg/util/maps"
 	"sigs.k8s.io/kueue/pkg/workload"
-
-	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
-	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 
 	workloadv1beta2 "github.com/project-codeflare/appwrapper/api/v1beta2"
 )

--- a/internal/controller/appwrapper_webhook.go
+++ b/internal/controller/appwrapper_webhook.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"fmt"
 
-	workloadv1beta2 "github.com/project-codeflare/appwrapper/api/v1beta2"
 	authv1 "k8s.io/api/authorization/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -31,11 +30,15 @@ import (
 	discovery "k8s.io/client-go/discovery"
 	"k8s.io/client-go/kubernetes"
 	authClientv1 "k8s.io/client-go/kubernetes/typed/authorization/v1"
+
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
+
+	workloadv1beta2 "github.com/project-codeflare/appwrapper/api/v1beta2"
 )
 
 type AppWrapperWebhook struct {

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -46,6 +46,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	workloadv1beta2 "github.com/project-codeflare/appwrapper/api/v1beta2"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
@@ -103,6 +104,8 @@ var _ = BeforeSuite(func() {
 	err = rbacv1.AddToScheme(scheme)
 	Expect(err).NotTo(HaveOccurred())
 	err = clientgoscheme.AddToScheme(scheme)
+	Expect(err).NotTo(HaveOccurred())
+	err = kueue.AddToScheme(scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	//+kubebuilder:scaffold:scheme

--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -23,6 +23,9 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+
+	workloadv1beta2 "github.com/project-codeflare/appwrapper/api/v1beta2"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 )
 
 // getPodTemplateSpec extracts a Kueue-compatible PodTemplateSpec at the given path within obj
@@ -56,6 +59,26 @@ func getPodTemplateSpec(obj *unstructured.Unstructured, path string) (*v1.PodTem
 	return template, nil
 }
 
+func getKueuePodSets(obj *unstructured.Unstructured, component *workloadv1beta2.AppWrapperComponent, awName string, componentIdx int) ([]kueue.PodSet, error) {
+	podSets := []kueue.PodSet{}
+	for psIdx, podSet := range component.PodSets {
+		replicas := int32(1)
+		if podSet.Replicas != nil {
+			replicas = *podSet.Replicas
+		}
+		template, err := getPodTemplateSpec(obj, podSet.Path)
+		if err != nil {
+			return nil, err
+		}
+		podSets = append(podSets, kueue.PodSet{
+			Name:     fmt.Sprintf("%s-%v-%v", awName, componentIdx, psIdx),
+			Template: *template,
+			Count:    replicas,
+		})
+	}
+	return podSets, nil
+}
+
 // return the subobject found at the given path, or nil if the path is invalid
 func getRawTemplate(obj map[string]interface{}, path string) (map[string]interface{}, error) {
 	parts := strings.Split(path, ".")
@@ -70,4 +93,8 @@ func getRawTemplate(obj map[string]interface{}, path string) (map[string]interfa
 		}
 	}
 	return obj, nil
+}
+
+func childWorkloadName(aw *workloadv1beta2.AppWrapper, componentNumber int) string {
+	return fmt.Sprintf("%v-%v", aw.UID, componentNumber)
 }

--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -94,7 +94,3 @@ func getRawTemplate(obj map[string]interface{}, path string) (map[string]interfa
 	}
 	return obj, nil
 }
-
-func childWorkloadName(aw *workloadv1beta2.AppWrapper, componentNumber int) string {
-	return fmt.Sprintf("%v-%v", aw.UID, componentNumber)
-}

--- a/internal/controller/workload_controller.go
+++ b/internal/controller/workload_controller.go
@@ -86,13 +86,13 @@ func (aw *AppWrapper) RunWithPodSetsInfo(podSetsInfo []podset.PodSetInfo) error 
 	podSetsInfoIndex := 0
 	for componentIdx := range aw.Spec.Components {
 		component := &aw.Spec.Components[componentIdx]
-		if len(component.PodSets) != len(component.PodSetInfos) {
+		if len(component.PodSetInfos) != len(component.PodSets) {
 			component.PodSetInfos = make([]workloadv1beta2.AppWrapperPodSetInfo, len(component.PodSets))
 		}
 		for podSetIdx := range component.PodSets {
 			podSetsInfoIndex += 1
 			if podSetsInfoIndex > len(podSetsInfo) {
-				continue // we're going to return an error below...just continuing to get an accurate count for the error message
+				continue // we will return an error below...continuing to get an accurate count for the error message
 			}
 			component.PodSetInfos[podSetIdx] = workloadv1beta2.AppWrapperPodSetInfo{
 				Annotations:  podSetsInfo[podSetIdx].Annotations,

--- a/internal/controller/workload_controller.go
+++ b/internal/controller/workload_controller.go
@@ -21,7 +21,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	"sigs.k8s.io/kueue/pkg/podset"

--- a/samples/wrapped-job.yaml
+++ b/samples/wrapped-job.yaml
@@ -22,7 +22,7 @@ spec:
             containers:
             - name: busybox
               image: quay.io/project-codeflare/busybox:1.36
-              command: ["sh", "-c", "sleep 600"]
+              command: ["sh", "-c", "sleep 30"]
               resources:
                 requests:
                   cpu: 1


### PR DESCRIPTION
If an AppWrapper contains a component that has its own Kueue-enabled controller, propagate the admission status 
of the AppWrapper to the component's Workload object.
