### PR TITLE
Enable standalone configuration

### DIFF
--- a/.github/workflows/CI-standalone.yaml
+++ b/.github/workflows/CI-standalone.yaml
@@ -54,7 +54,7 @@ jobs:
       run: |
         make install -e GIT_BRANCH=${{ env.GIT_BRANCH }} TAG=${{ env.GIT_BRANCH }}-${{ env.TAG }}
         make kind-push -e GIT_BRANCH=${{ env.GIT_BRANCH }} TAG=${{ env.GIT_BRANCH }}-${{ env.TAG }}
-        make deploy-standalone -e GIT_BRANCH=${{ env.GIT_BRANCH }} TAG=${{ env.GIT_BRANCH }}-${{ env.TAG }}
+        make deploy-aw -e GIT_BRANCH=${{ env.GIT_BRANCH }} TAG=${{ env.GIT_BRANCH }}-${{ env.TAG }}
 
     - name: Run E2E tests
       run: LABEL_FILTER="Standalone" ./hack/run-tests-on-cluster.sh

--- a/.github/workflows/CI-standalone.yaml
+++ b/.github/workflows/CI-standalone.yaml
@@ -1,4 +1,4 @@
-name: CI
+name: CI-standalone
 on:
   push:
     branches: [main]
@@ -48,16 +48,13 @@ jobs:
       run: make test
 
     - name: Create and configure cluster
-      run: LABEL_FILTER=Kueue ./hack/create-test-cluster.sh
-
-    - name: Deploy Kueue
-      run: ./hack/deploy-kueue.sh
+      run: ./hack/create-test-cluster.sh
 
     - name: Deploy AppWrapper controller
       run: |
         make install -e GIT_BRANCH=${{ env.GIT_BRANCH }} TAG=${{ env.GIT_BRANCH }}-${{ env.TAG }}
         make kind-push -e GIT_BRANCH=${{ env.GIT_BRANCH }} TAG=${{ env.GIT_BRANCH }}-${{ env.TAG }}
-        make deploy -e GIT_BRANCH=${{ env.GIT_BRANCH }} TAG=${{ env.GIT_BRANCH }}-${{ env.TAG }}
+        make deploy-standalone -e GIT_BRANCH=${{ env.GIT_BRANCH }} TAG=${{ env.GIT_BRANCH }}-${{ env.TAG }}
 
     - name: Run E2E tests
-      run: ./hack/run-tests-on-cluster.sh
+      run: LABEL_FILTER="Standalone" ./hack/run-tests-on-cluster.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ COPY go.sum go.sum
 RUN go mod download
 
 # Copy the go source
-COPY cmd/main.go cmd/main.go
+COPY cmd/ cmd/
 COPY api/ api/
 COPY internal/ internal/
 
@@ -21,13 +21,15 @@ COPY internal/ internal/
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/unified/main.go
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager-aw cmd/standalone/main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /
 COPY --from=builder /workspace/manager .
+COPY --from=builder /workspace/manager-aw .
 USER 65532:65532
 
-ENTRYPOINT ["/manager"]
+CMD ["/manager"]

--- a/cmd/standalone/main.go
+++ b/cmd/standalone/main.go
@@ -1,0 +1,154 @@
+/*
+Copyright 2024 IBM Corporation.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"crypto/tls"
+	"flag"
+	"os"
+
+	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
+	// to ensure that exec-entrypoint and run can make use of them.
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	workloadv1beta2 "github.com/project-codeflare/appwrapper/api/v1beta2"
+	"github.com/project-codeflare/appwrapper/internal/config"
+	"github.com/project-codeflare/appwrapper/internal/controller"
+	//+kubebuilder:scaffold:imports
+)
+
+var (
+	scheme       = runtime.NewScheme()
+	setupLog     = ctrl.Log.WithName("setup")
+	BuildVersion = "UNKNOWN"
+	BuildDate    = "UNKNOWN"
+)
+
+func init() {
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(workloadv1beta2.AddToScheme(scheme))
+	//+kubebuilder:scaffold:scheme
+}
+
+func main() {
+	var metricsAddr string
+	var enableLeaderElection bool
+	var probeAddr string
+	var secureMetrics bool
+	var enableHTTP2 bool
+
+	awConfig := config.AppWrapperConfig{StandaloneMode: true, ManageJobsWithoutQueueName: false}
+
+	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
+	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
+	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
+		"Enable leader election for controller manager. "+
+			"Enabling this will ensure there is only one active controller manager.")
+	flag.BoolVar(&secureMetrics, "metrics-secure", false,
+		"If set the metrics endpoint is served securely")
+	flag.BoolVar(&enableHTTP2, "enable-http2", false,
+		"If set, HTTP/2 will be enabled for the metrics and webhook servers")
+	opts := zap.Options{
+		Development: true,
+	}
+	opts.BindFlags(flag.CommandLine)
+	flag.Parse()
+
+	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+	setupLog.Info("Build info", "version", BuildVersion, "date", BuildDate)
+	setupLog.Info("Configuration", "config", awConfig)
+
+	// if the enable-http2 flag is false (the default), http/2 should be disabled
+	// due to its vulnerabilities. More specifically, disabling http/2 will
+	// prevent from being vulnerable to the HTTP/2 Stream Cancelation and
+	// Rapid Reset CVEs. For more information see:
+	// - https://github.com/advisories/GHSA-qppj-fm5r-hxr3
+	// - https://github.com/advisories/GHSA-4374-p667-p6c8
+	disableHTTP2 := func(c *tls.Config) {
+		setupLog.Info("disabling http/2")
+		c.NextProtos = []string{"http/1.1"}
+	}
+
+	tlsOpts := []func(*tls.Config){}
+	if !enableHTTP2 {
+		tlsOpts = append(tlsOpts, disableHTTP2)
+	}
+
+	webhookServer := webhook.NewServer(webhook.Options{
+		TLSOpts: tlsOpts,
+	})
+
+	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+		Scheme: scheme,
+		Metrics: metricsserver.Options{
+			BindAddress:   metricsAddr,
+			SecureServing: secureMetrics,
+			TLSOpts:       tlsOpts,
+		},
+		WebhookServer:          webhookServer,
+		HealthProbeBindAddress: probeAddr,
+		LeaderElection:         enableLeaderElection,
+		LeaderElectionID:       "f134c674.codeflare.dev",
+		// LeaderElectionReleaseOnCancel defines if the leader should step down voluntarily
+		// when the Manager ends. This requires the binary to immediately end when the
+		// Manager is stopped, otherwise, this setting is unsafe. Setting this significantly
+		// speeds up voluntary leader transitions as the new leader don't have to wait
+		// LeaseDuration time first.
+		//
+		// In the default scaffold provided, the program ends immediately after
+		// the manager stops, so would be fine to enable this option. However,
+		// if you are doing or is intended to do any operation such as perform cleanups
+		// after the manager stops then its usage might be unsafe.
+		// LeaderElectionReleaseOnCancel: true,
+	})
+	if err != nil {
+		setupLog.Error(err, "unable to start manager")
+		os.Exit(1)
+	}
+
+	ctx := ctrl.SetupSignalHandler()
+	err = controller.SetupWithManager(ctx, mgr, &awConfig)
+	if err != nil {
+		setupLog.Error(err, "unable to start appwrapper controllers")
+		os.Exit(1)
+	}
+
+	//+kubebuilder:scaffold:builder
+	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
+		setupLog.Error(err, "unable to set up health check")
+		os.Exit(1)
+	}
+	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
+		setupLog.Error(err, "unable to set up ready check")
+		os.Exit(1)
+	}
+
+	setupLog.Info("starting manager")
+	if err := mgr.Start(ctx); err != nil {
+		setupLog.Error(err, "problem running manager")
+		os.Exit(1)
+	}
+}

--- a/cmd/unified/main.go
+++ b/cmd/unified/main.go
@@ -62,7 +62,7 @@ func main() {
 	var secureMetrics bool
 	var enableHTTP2 bool
 
-	awConfig := config.AppWrapperConfig{}
+	awConfig := config.AppWrapperConfig{StandaloneMode: false}
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")

--- a/config/standalone/kustomization.yaml
+++ b/config/standalone/kustomization.yaml
@@ -1,0 +1,142 @@
+# Adds namespace to all resources.
+namespace: appwrapper-system
+
+# Value of this field is prepended to the
+# names of all resources, e.g. a deployment named
+# "wordpress" becomes "alices-wordpress".
+# Note that it should also match with the prefix (text before '-') of the namespace
+# field above.
+namePrefix: appwrapper-
+
+# Labels to add to all resources and selectors.
+#labels:
+#- includeSelectors: true
+#  pairs:
+#    someName: someValue
+
+resources:
+- ../crd
+- ../rbac
+- ../manager
+# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
+# crd/kustomization.yaml
+- ../webhook
+# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
+- ../certmanager
+# [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
+#- ../prometheus
+
+patches:
+# Protect the /metrics endpoint by putting it behind auth.
+# If you want your controller-manager to expose the /metrics
+# endpoint w/o any authn/z, please comment the following line.
+- path: manager_auth_proxy_patch.yaml
+
+# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
+# crd/kustomization.yaml
+- path: manager_webhook_patch.yaml
+
+# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
+# Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.
+# 'CERTMANAGER' needs to be enabled to use ca injection
+- path: webhookcainjection_patch.yaml
+
+# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.
+# Uncomment the following replacements to add the cert-manager CA injection annotations
+replacements:
+- source: # Add cert-manager annotation to ValidatingWebhookConfiguration, MutatingWebhookConfiguration and CRDs
+    kind: Certificate
+    group: cert-manager.io
+    version: v1
+    name: serving-cert # this name should match the one in certificate.yaml
+    fieldPath: .metadata.namespace # namespace of the certificate CR
+  targets:
+  - select:
+      kind: ValidatingWebhookConfiguration
+    fieldPaths:
+    - .metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: '/'
+      index: 0
+      create: true
+  - select:
+      kind: MutatingWebhookConfiguration
+    fieldPaths:
+    - .metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: '/'
+      index: 0
+      create: true
+  - select:
+      kind: CustomResourceDefinition
+    fieldPaths:
+    - .metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: '/'
+      index: 0
+      create: true
+- source:
+    kind: Certificate
+    group: cert-manager.io
+    version: v1
+    name: serving-cert # this name should match the one in certificate.yaml
+    fieldPath: .metadata.name
+  targets:
+  - select:
+      kind: ValidatingWebhookConfiguration
+    fieldPaths:
+    - .metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: '/'
+      index: 1
+      create: true
+  - select:
+      kind: MutatingWebhookConfiguration
+    fieldPaths:
+    - .metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: '/'
+      index: 1
+      create: true
+  - select:
+      kind: CustomResourceDefinition
+    fieldPaths:
+    - .metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: '/'
+      index: 1
+      create: true
+- source: # Add cert-manager annotation to the webhook Service
+    kind: Service
+    version: v1
+    name: webhook-service
+    fieldPath: .metadata.name # namespace of the service
+  targets:
+  - select:
+      kind: Certificate
+      group: cert-manager.io
+      version: v1
+    fieldPaths:
+    - .spec.dnsNames.0
+    - .spec.dnsNames.1
+    options:
+      delimiter: '.'
+      index: 0
+      create: true
+- source:
+    kind: Service
+    version: v1
+    name: webhook-service
+    fieldPath: .metadata.namespace # namespace of the service
+  targets:
+  - select:
+      kind: Certificate
+      group: cert-manager.io
+      version: v1
+    fieldPaths:
+    - .spec.dnsNames.0
+    - .spec.dnsNames.1
+    options:
+      delimiter: '.'
+      index: 1
+      create: true

--- a/config/standalone/manager_auth_proxy_patch.yaml
+++ b/config/standalone/manager_auth_proxy_patch.yaml
@@ -1,0 +1,41 @@
+# This patch inject a sidecar container which is a HTTP proxy for the
+# controller manager, it performs RBAC authorization against the Kubernetes API using SubjectAccessReviews.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: kube-rbac-proxy
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - "ALL"
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0
+        args:
+        - "--secure-listen-address=0.0.0.0:8443"
+        - "--upstream=http://127.0.0.1:8080/"
+        - "--logtostderr=true"
+        - "--v=0"
+        ports:
+        - containerPort: 8443
+          protocol: TCP
+          name: https
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 5m
+            memory: 64Mi
+      - name: manager
+        command:
+        - /manager-aw
+        args:
+        - "--health-probe-bind-address=:8081"
+        - "--metrics-bind-address=127.0.0.1:8080"
+        - "--leader-elect"

--- a/config/standalone/manager_config_patch.yaml
+++ b/config/standalone/manager_config_patch.yaml
@@ -1,0 +1,10 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager

--- a/config/standalone/manager_webhook_patch.yaml
+++ b/config/standalone/manager_webhook_patch.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: webhook-server-cert

--- a/config/standalone/webhookcainjection_patch.yaml
+++ b/config/standalone/webhookcainjection_patch.yaml
@@ -1,0 +1,29 @@
+# This patch add annotation to admission webhook config and
+# CERTIFICATE_NAMESPACE and CERTIFICATE_NAME will be substituted by kustomize
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  labels:
+    app.kubernetes.io/name: mutatingwebhookconfiguration
+    app.kubernetes.io/instance: mutating-webhook-configuration
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/created-by: appwrapper
+    app.kubernetes.io/part-of: appwrapper
+    app.kubernetes.io/managed-by: kustomize
+  name: mutating-webhook-configuration
+  annotations:
+    cert-manager.io/inject-ca-from: CERTIFICATE_NAMESPACE/CERTIFICATE_NAME
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    app.kubernetes.io/name: validatingwebhookconfiguration
+    app.kubernetes.io/instance: validating-webhook-configuration
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/created-by: appwrapper
+    app.kubernetes.io/part-of: appwrapper
+    app.kubernetes.io/managed-by: kustomize
+  name: validating-webhook-configuration
+  annotations:
+    cert-manager.io/inject-ca-from: CERTIFICATE_NAMESPACE/CERTIFICATE_NAME

--- a/hack/run-tests-on-cluster.sh
+++ b/hack/run-tests-on-cluster.sh
@@ -19,6 +19,7 @@ export GORACE=1
 export CLEANUP_CLUSTER=${CLEANUP_CLUSTER:-"false"}
 export CLUSTER_STARTED="true"
 export KUTTL_TEST_SUITES=("")
+export LABEL_FILTER=${LABEL_FILTER:-"Kueue"}
 
 source ${ROOT_DIR}/hack/e2e-util.sh
 
@@ -27,7 +28,7 @@ trap cleanup EXIT
 wait_for_appwrapper_controller
 
 run_kuttl_test_suite
-go run github.com/onsi/ginkgo/v2/ginkgo -v -fail-fast --procs 1 -timeout 130m ./test/e2e
+go run github.com/onsi/ginkgo/v2/ginkgo -v -fail-fast --procs 1 -timeout 130m --label-filter=${LABEL_FILTER} ./test/e2e
 
 RC=$?
 if [ ${RC} -eq 0 ]

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,4 +18,5 @@ package config
 
 type AppWrapperConfig struct {
 	ManageJobsWithoutQueueName bool `json:"manageJobsWithoutQueueName,omitempty"`
+	StandaloneMode             bool `json:"standaloneMode,omitempty"`
 }

--- a/internal/controller/appwrapper/appwrapper_controller_test.go
+++ b/internal/controller/appwrapper/appwrapper_controller_test.go
@@ -29,6 +29,7 @@ import (
 	utilslices "sigs.k8s.io/kueue/pkg/util/slices"
 
 	workloadv1beta2 "github.com/project-codeflare/appwrapper/api/v1beta2"
+	"github.com/project-codeflare/appwrapper/internal/config"
 	"github.com/project-codeflare/appwrapper/internal/controller/workload"
 	"github.com/project-codeflare/appwrapper/internal/utils"
 )
@@ -115,6 +116,7 @@ var _ = Describe("AppWrapper Controller", func() {
 		awReconciler = &AppWrapperReconciler{
 			Client: k8sClient,
 			Scheme: k8sClient.Scheme(),
+			Config: &config.AppWrapperConfig{ManageJobsWithoutQueueName: true, StandaloneMode: false},
 		}
 		kueuePodSets = (*workload.AppWrapper)(aw).PodSets()
 	})

--- a/samples/wrapped-deployment.yaml
+++ b/samples/wrapped-deployment.yaml
@@ -5,7 +5,6 @@ metadata:
   annotations:
     kueue.x-k8s.io/queue-name: user-queue
 spec:
-  suspend: true
   components:
   - podSets:
     - replicas: 2

--- a/samples/wrapped-job.yaml
+++ b/samples/wrapped-job.yaml
@@ -5,7 +5,6 @@ metadata:
   annotations:
     kueue.x-k8s.io/queue-name: user-queue
 spec:
-  suspend: true
   components:
   - podSets:
     - replicas: 1

--- a/samples/wrapped-pod.yaml
+++ b/samples/wrapped-pod.yaml
@@ -5,7 +5,6 @@ metadata:
   annotations:
     kueue.x-k8s.io/queue-name: user-queue
 spec:
-  suspend: true
   components:
   - podSets:
     - replicas: 1

--- a/samples/wrapped-pytorch-job.yaml
+++ b/samples/wrapped-pytorch-job.yaml
@@ -5,7 +5,6 @@ metadata:
   annotations:
     kueue.x-k8s.io/queue-name: user-queue
 spec:
-  suspend: true
   components:
   - podSets:
     - replicas: 1

--- a/test/e2e/appwrapper_test.go
+++ b/test/e2e/appwrapper_test.go
@@ -37,7 +37,7 @@ var _ = Describe("AppWrapper E2E Test", func() {
 		cleanupTestObjects(ctx, appwrappers)
 	})
 
-	Describe("Creation of Fundamental GVKs", func() {
+	Describe("Creation of Fundamental GVKs", Label("Kueue", "Standalone"), func() {
 		It("Pods", func() {
 			aw := createAppWrapper(ctx, pod(250), pod(250))
 			appwrappers = append(appwrappers, aw)
@@ -66,7 +66,7 @@ var _ = Describe("AppWrapper E2E Test", func() {
 		})
 	})
 
-	Describe("Creation of Kubeflow Training Operator GVKs", func() {
+	Describe("Creation of Kubeflow Training Operator GVKs", Label("Kueue", "Standalone"), func() {
 		It("PyTorch Jobs", func() {
 			aw := createAppWrapper(ctx, pytorchjob(2, 250))
 			appwrappers = append(appwrappers, aw)
@@ -82,7 +82,7 @@ var _ = Describe("AppWrapper E2E Test", func() {
 
 	})
 
-	Describe("Queueing and Preemption", func() {
+	Describe("Queueing and Preemption", Label("Kueue"), func() {
 		It("Basic Queuing", Label("slow"), func() {
 			By("Jobs should be admitted when there is available quota")
 			aw := createAppWrapper(ctx, deployment(2, 500))
@@ -106,7 +106,7 @@ var _ = Describe("AppWrapper E2E Test", func() {
 
 	})
 
-	Describe("Recognition of Child Jobs", func() {
+	Describe("Recognition of Child Jobs", Label("Kueue"), func() {
 		// TODO: Test scenarios where the AW "just fits" in the quota and
 		//       contains components that Kueue might try to queue
 		//       but should not in this case because they are using the parent workload's quota
@@ -115,11 +115,11 @@ var _ = Describe("AppWrapper E2E Test", func() {
 
 	})
 
-	Describe("Detection of Completion Status", func() {
+	Describe("Detection of Completion Status", Label("Kueue", "Standalone"), func() {
 
 	})
 
-	Describe("Load Testing", Label("slow"), func() {
+	Describe("Load Testing", Label("slow"), Label("Kueue", "Standalone"), func() {
 
 	})
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -33,7 +33,9 @@ var _ = BeforeSuite(func() {
 	log.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 	ctx = extendContextWithClient(context.Background())
 	ensureNamespaceExists(ctx)
-	ensureTestQueuesExist(ctx)
+	if Label("Kueue").MatchesLabelFilter(GinkgoLabelFilter()) {
+		ensureTestQueuesExist(ctx)
+	}
 })
 
 func TestE2E(t *testing.T) {


### PR DESCRIPTION
Enable a standalone configuration of the AppWrapper controller that can be run without assuming a Kueue installation. In this mode, the AppWrapper controller still obeys the "Suspend protocol", but assumes that all changes to the value of Suspend are done externally.
