### PR TITLE
bug fix: podSets should not be required

### DIFF
--- a/api/v1beta2/appwrapper_types.go
+++ b/api/v1beta2/appwrapper_types.go
@@ -34,7 +34,7 @@ type AppWrapperSpec struct {
 // AppWrapperComponent describes a wrapped resource
 type AppWrapperComponent struct {
 	// PodSets contained in the component
-	PodSets []AppWrapperPodSet `json:"podSets"`
+	PodSets []AppWrapperPodSet `json:"podSets,omitempty"`
 
 	// PodSetInfos assigned to the Component by Kueue
 	PodSetInfos []AppWrapperPodSetInfo `json:"podSetInfos,omitempty"`

--- a/config/crd/bases/workload.codeflare.dev_appwrappers.yaml
+++ b/config/crd/bases/workload.codeflare.dev_appwrappers.yaml
@@ -127,7 +127,6 @@ spec:
                       x-kubernetes-embedded-resource: true
                       x-kubernetes-preserve-unknown-fields: true
                   required:
-                  - podSets
                   - template
                   type: object
                 type: array


### PR DESCRIPTION
If a Component does not contain any PodSpecTemplates, then PodSet is not required.
