### PR TITLE
detect missing podSetInfo and raise fatal error

### DIFF
--- a/internal/controller/appwrapper/resource_management.go
+++ b/internal/controller/appwrapper/resource_management.go
@@ -90,7 +90,11 @@ func (r *AppWrapperReconciler) createComponent(ctx context.Context, aw *workload
 	for podSetsIdx, podSet := range component.PodSets {
 		toInject := &workloadv1beta2.AppWrapperPodSetInfo{}
 		if !r.Config.StandaloneMode {
-			toInject = &component.PodSetInfos[podSetsIdx]
+			if podSetsIdx < len(component.PodSetInfos) {
+				toInject = &component.PodSetInfos[podSetsIdx]
+			} else {
+				return nil, fmt.Errorf("missing podSetInfo %v for component %v", podSetsIdx, componentIdx), true
+			}
 		}
 
 		p, err := utils.GetRawTemplate(obj.UnstructuredContent(), podSet.Path)


### PR DESCRIPTION
Avoid crashing the operator with an index-out-of-bounds panic when a misconfiguration results in a workload being in the Resuming phase without the expected assignment of PodSetInfos by Kueue. This can happen when running in dev mode (no webhooks) and the input appwrapper yaml didn't explicitly set suspend to True.
