### PR TITLE
revert Dockerfile back to defining an entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,4 +31,4 @@ WORKDIR /
 COPY --from=builder /workspace/manager .
 USER 65532:65532
 
-CMD ["/manager"]
+ENTRYPOINT ["/manager"]


### PR DESCRIPTION
Now that we are back to only 1 manager binary in the Dockerfile, we can use entrypoint instead of command to lock down what is run.
