### PR TITLE
Infer pod sets for known GVKs

### DIFF
--- a/internal/webhook/appwrapper_fixtures_test.go
+++ b/internal/webhook/appwrapper_fixtures_test.go
@@ -396,6 +396,20 @@ func rayCluster(workerCount int, milliCPU int64) workloadv1beta2.AppWrapperCompo
 	}
 }
 
+func rayClusterForInference(workerCount int, milliCPU int64) workloadv1beta2.AppWrapperComponent {
+	workerCPU := resource.NewMilliQuantity(milliCPU, resource.DecimalSI)
+	yamlString := fmt.Sprintf(rayClusterYAML,
+		randName("raycluster"),
+		workerCount, workerCount, workerCount,
+		workerCPU)
+
+	jsonBytes, err := yaml.YAMLToJSON([]byte(yamlString))
+	Expect(err).NotTo(HaveOccurred())
+	return workloadv1beta2.AppWrapperComponent{
+		Template: runtime.RawExtension{Raw: jsonBytes},
+	}
+}
+
 const jobSetYAML = `
 apiVersion: jobset.x-k8s.io/v1alpha2
 kind: JobSet

--- a/internal/webhook/appwrapper_fixtures_test.go
+++ b/internal/webhook/appwrapper_fixtures_test.go
@@ -86,6 +86,18 @@ func pod(milliCPU int64) workloadv1beta2.AppWrapperComponent {
 	}
 }
 
+func podForInference(milliCPU int64) workloadv1beta2.AppWrapperComponent {
+	yamlString := fmt.Sprintf(podYAML,
+		randName("pod"),
+		resource.NewMilliQuantity(milliCPU, resource.DecimalSI))
+
+	jsonBytes, err := yaml.YAMLToJSON([]byte(yamlString))
+	Expect(err).NotTo(HaveOccurred())
+	return workloadv1beta2.AppWrapperComponent{
+		Template: runtime.RawExtension{Raw: jsonBytes},
+	}
+}
+
 const namespacedPodYAML = `
 apiVersion: v1
 kind: Pod
@@ -175,6 +187,19 @@ func deployment(replicaCount int, milliCPU int64) workloadv1beta2.AppWrapperComp
 	Expect(err).NotTo(HaveOccurred())
 	return workloadv1beta2.AppWrapperComponent{
 		PodSets:  []workloadv1beta2.AppWrapperPodSet{{Replicas: ptr.To(int32(replicaCount)), Path: "template.spec.template"}},
+		Template: runtime.RawExtension{Raw: jsonBytes},
+	}
+}
+
+func deploymentForInference(replicaCount int, milliCPU int64) workloadv1beta2.AppWrapperComponent {
+	yamlString := fmt.Sprintf(deploymentYAML,
+		randName("deployment"),
+		replicaCount,
+		resource.NewMilliQuantity(milliCPU, resource.DecimalSI))
+
+	jsonBytes, err := yaml.YAMLToJSON([]byte(yamlString))
+	Expect(err).NotTo(HaveOccurred())
+	return workloadv1beta2.AppWrapperComponent{
 		Template: runtime.RawExtension{Raw: jsonBytes},
 	}
 }
@@ -423,6 +448,90 @@ func jobSet(replicasWorker int, milliCPUWorker int64) workloadv1beta2.AppWrapper
 			{Path: "template.spec.replicatedJobs[0].template.spec.template"},
 			{Replicas: ptr.To(int32(replicasWorker)), Path: "template.spec.replicatedJobs[1].template.spec.template"},
 		},
+		Template: runtime.RawExtension{Raw: jsonBytes},
+	}
+}
+
+const jobYAML = `
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: %v
+spec:
+  parallelism: %v
+  completions: %v
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: busybox
+        image: quay.io/project-codeflare/busybox:1.36
+        command: ["sh", "-c", "sleep 30"]
+        resources:
+          requests:
+            cpu: %v`
+
+func jobForInference(parallelism int, completions int, milliCPU int64) workloadv1beta2.AppWrapperComponent {
+	yamlString := fmt.Sprintf(jobYAML,
+		randName("job"),
+		parallelism,
+		completions,
+		resource.NewMilliQuantity(milliCPU, resource.DecimalSI))
+
+	jsonBytes, err := yaml.YAMLToJSON([]byte(yamlString))
+	Expect(err).NotTo(HaveOccurred())
+	return workloadv1beta2.AppWrapperComponent{
+		Template: runtime.RawExtension{Raw: jsonBytes},
+	}
+}
+
+const pytorchJobYAML = `
+apiVersion: "kubeflow.org/v1"
+kind: PyTorchJob
+metadata:
+  name: %v
+spec:
+  pytorchReplicaSpecs:
+    Master:
+      restartPolicy: OnFailure
+      template:
+        spec:
+          containers:
+          - name: pytorch
+            image: docker.io/kubeflowkatib/pytorch-mnist-cpu:v1beta1-fc858d1
+            command:
+            - "python3"
+            - "/opt/pytorch-mnist/mnist.py"
+            - "--epochs=1"
+            resources:
+              requests:
+                cpu: %v
+    Worker:
+      replicas: %v
+      restartPolicy: OnFailure
+      template:
+        spec:
+          containers:
+          - name: pytorch
+            image: docker.io/kubeflowkatib/pytorch-mnist-cpu:v1beta1-fc858d1
+            command:
+            - "python3"
+            - "/opt/pytorch-mnist/mnist.py"
+            - "--epochs=1"
+            resources:
+              requests:
+                cpu: %v`
+
+func pytorchJobForInference(masterMilliCPU int64, workerReplicas int, workerMilliCPU int64) workloadv1beta2.AppWrapperComponent {
+	yamlString := fmt.Sprintf(pytorchJobYAML,
+		randName("pytorch-job"),
+		resource.NewMilliQuantity(masterMilliCPU, resource.DecimalSI),
+		workerReplicas,
+		resource.NewMilliQuantity(workerMilliCPU, resource.DecimalSI))
+
+	jsonBytes, err := yaml.YAMLToJSON([]byte(yamlString))
+	Expect(err).NotTo(HaveOccurred())
+	return workloadv1beta2.AppWrapperComponent{
 		Template: runtime.RawExtension{Raw: jsonBytes},
 	}
 }

--- a/internal/webhook/appwrapper_webhook_test.go
+++ b/internal/webhook/appwrapper_webhook_test.go
@@ -190,6 +190,15 @@ var _ = Describe("AppWrapper Webhook Tests", func() {
 			Expect(aw.Spec.Suspend).Should(BeTrue())
 			Expect(k8sClient.Delete(ctx, aw)).To(Succeed())
 		})
+
+		It("PodSets are inferred for known GVKs", func() {
+			aw := toAppWrapper(pod(100), deploymentForInference(1, 100), podForInference(100),
+				jobForInference(2, 4, 100), jobForInference(8, 4, 100), pytorchJobForInference(100, 4, 100))
+
+			Expect(k8sClient.Create(ctx, aw)).To(Succeed(), "PodSets for deployments and pods should be inferred")
+			Expect(aw.Spec.Suspend).Should(BeTrue())
+			Expect(k8sClient.Delete(ctx, aw)).To(Succeed())
+		})
 	})
 
 })

--- a/internal/webhook/appwrapper_webhook_test.go
+++ b/internal/webhook/appwrapper_webhook_test.go
@@ -191,13 +191,23 @@ var _ = Describe("AppWrapper Webhook Tests", func() {
 			Expect(k8sClient.Delete(ctx, aw)).To(Succeed())
 		})
 
-		It("PodSets are inferred for known GVKs", func() {
-			aw := toAppWrapper(pod(100), deploymentForInference(1, 100), podForInference(100),
-				jobForInference(2, 4, 100), jobForInference(8, 4, 100), pytorchJobForInference(100, 4, 100))
+		Context("PodSets are inferred for known GVKs", func() {
+			It("PodSets are inferred for common kinds", func() {
+				aw := toAppWrapper(pod(100), deploymentForInference(1, 100), podForInference(100),
+					jobForInference(2, 4, 100), jobForInference(8, 4, 100))
 
-			Expect(k8sClient.Create(ctx, aw)).To(Succeed(), "PodSets for deployments and pods should be inferred")
-			Expect(aw.Spec.Suspend).Should(BeTrue())
-			Expect(k8sClient.Delete(ctx, aw)).To(Succeed())
+				Expect(k8sClient.Create(ctx, aw)).To(Succeed(), "PodSets should be inferred")
+				Expect(aw.Spec.Suspend).Should(BeTrue())
+				Expect(k8sClient.Delete(ctx, aw)).To(Succeed())
+			})
+
+			It("PodSets are inferred for PyTorchJobs and RayClusters", func() {
+				aw := toAppWrapper(pytorchJobForInference(100, 4, 100), rayClusterForInference(7, 100))
+
+				Expect(k8sClient.Create(ctx, aw)).To(Succeed(), "PodSets should be inferred")
+				Expect(aw.Spec.Suspend).Should(BeTrue())
+				Expect(k8sClient.Delete(ctx, aw)).To(Succeed())
+			})
 		})
 	})
 

--- a/internal/webhook/appwrapper_webhook_test.go
+++ b/internal/webhook/appwrapper_webhook_test.go
@@ -201,8 +201,8 @@ var _ = Describe("AppWrapper Webhook Tests", func() {
 				Expect(k8sClient.Delete(ctx, aw)).To(Succeed())
 			})
 
-			It("PodSets are inferred for PyTorchJobs and RayClusters", func() {
-				aw := toAppWrapper(pytorchJobForInference(100, 4, 100), rayClusterForInference(7, 100))
+			It("PodSets are inferred for PyTorchJobs, RayClusters, and RayJobs", func() {
+				aw := toAppWrapper(pytorchJobForInference(100, 4, 100), rayClusterForInference(7, 100), rayJobForInference(7, 100))
 
 				Expect(k8sClient.Create(ctx, aw)).To(Succeed(), "PodSets should be inferred")
 				Expect(aw.Spec.Suspend).Should(BeTrue())


### PR DESCRIPTION
This PR extends the defaulting webhook to infer pod sets for components such as pods and deployments when not explicitly specified.