### PR TITLE
Drop replicaPath from CRD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
 
 .PHONY: generate-apiref
-generate-apiref: genref
+generate-apiref: genref ## Generate API Reference for project website.
 	cd  site/genref && $(GENREF)  -o ../_pages
 
 .PHONY: fmt

--- a/api/v1beta2/appwrapper_types.go
+++ b/api/v1beta2/appwrapper_types.go
@@ -59,10 +59,6 @@ type AppWrapperPodSet struct {
 	//+optional
 	Replicas *int32 `json:"replicas,omitempty"`
 
-	// ReplicaPath is the path within Component.Template to the replica count for this PodSet
-	//+optional
-	ReplicaPath string `json:"replicaPath,omitempty"`
-
 	// PodPath is the path Component.Template to the PodTemplateSpec for this PodSet
 	PodPath string `json:"podPath"`
 }

--- a/config/crd/bases/workload.codeflare.dev_appwrappers.yaml
+++ b/config/crd/bases/workload.codeflare.dev_appwrappers.yaml
@@ -138,10 +138,6 @@ spec:
                             description: PodPath is the path Component.Template to
                               the PodTemplateSpec for this PodSet
                             type: string
-                          replicaPath:
-                            description: ReplicaPath is the path within Component.Template
-                              to the replica count for this PodSet
-                            type: string
                           replicas:
                             description: Replicas is the number of pods in this PodSet
                             format: int32

--- a/internal/webhook/appwrapper_fixtures_test.go
+++ b/internal/webhook/appwrapper_fixtures_test.go
@@ -174,7 +174,7 @@ func deployment(replicaCount int, milliCPU int64) workloadv1beta2.AppWrapperComp
 	jsonBytes, err := yaml.YAMLToJSON([]byte(yamlString))
 	Expect(err).NotTo(HaveOccurred())
 	return workloadv1beta2.AppWrapperComponent{
-		PodSets:  []workloadv1beta2.AppWrapperPodSet{{ReplicaPath: "template.spec.replicas", PodPath: "template.spec.template"}},
+		PodSets:  []workloadv1beta2.AppWrapperPodSet{{Replicas: ptr.To(int32(replicaCount)), PodPath: "template.spec.template"}},
 		Template: runtime.RawExtension{Raw: jsonBytes},
 	}
 }
@@ -365,7 +365,7 @@ func rayCluster(workerCount int, milliCPU int64) workloadv1beta2.AppWrapperCompo
 	return workloadv1beta2.AppWrapperComponent{
 		PodSets: []workloadv1beta2.AppWrapperPodSet{
 			{Replicas: ptr.To(int32(1)), PodPath: "template.spec.headGroupSpec.template"},
-			{ReplicaPath: "template.spec.workerGroupSpecs[0].maxReplicas", PodPath: "template.spec.workerGroupSpecs[0].template"},
+			{Replicas: ptr.To(int32(workerCount)), PodPath: "template.spec.workerGroupSpecs[0].template"},
 		},
 		Template: runtime.RawExtension{Raw: jsonBytes},
 	}
@@ -421,7 +421,7 @@ func jobSet(replicasWorker int, milliCPUWorker int64) workloadv1beta2.AppWrapper
 	return workloadv1beta2.AppWrapperComponent{
 		PodSets: []workloadv1beta2.AppWrapperPodSet{
 			{PodPath: "template.spec.replicatedJobs[0].template.spec.template"},
-			{ReplicaPath: "template.spec.replicatedJobs[1].template.spec.parallelism", PodPath: "template.spec.replicatedJobs[1].template.spec.template"},
+			{Replicas: ptr.To(int32(replicasWorker)), PodPath: "template.spec.replicatedJobs[1].template.spec.template"},
 		},
 		Template: runtime.RawExtension{Raw: jsonBytes},
 	}

--- a/samples/wrapped-deployment.yaml
+++ b/samples/wrapped-deployment.yaml
@@ -7,8 +7,8 @@ metadata:
 spec:
   components:
   - podSets:
-    - podPath: template.spec.template
-      replicaPath: template.spec.replicas
+    - replicas: 1
+      podPath: template.spec.template
     template:
       apiVersion: apps/v1
       kind: Deployment

--- a/samples/wrapped-pytorch-job.yaml
+++ b/samples/wrapped-pytorch-job.yaml
@@ -7,10 +7,10 @@ metadata:
 spec:
   components:
   - podSets:
-    - podPath: template.spec.pytorchReplicaSpecs.Master.template
-      replicaPath: template.spec.pytorchReplicaSpecs.Master.replicas
-    - podPath: template.spec.pytorchReplicaSpecs.Worker.template
-      replicaPath: template.spec.pytorchReplicaSpecs.Worker.replicas
+    - replicas: 1
+      podPath: template.spec.pytorchReplicaSpecs.Master.template
+    - replicas: 1
+      podPath: template.spec.pytorchReplicaSpecs.Worker.template
     template:
       apiVersion: "kubeflow.org/v1"
       kind: PyTorchJob

--- a/site/_pages/appwrapper.v1beta2.md
+++ b/site/_pages/appwrapper.v1beta2.md
@@ -126,13 +126,6 @@ arbitrary metadata about the Component to customize its treatment by the AppWrap
    <p>Replicas is the number of pods in this PodSet</p>
 </td>
 </tr>
-<tr><td><code>replicaPath</code><br/>
-<code>string</code>
-</td>
-<td>
-   <p>ReplicaPath is the path within Component.Template to the replica count for this PodSet</p>
-</td>
-</tr>
 <tr><td><code>podPath</code> <B>[Required]</B><br/>
 <code>string</code>
 </td>

--- a/site/_pages/sample-pytorch.md
+++ b/site/_pages/sample-pytorch.md
@@ -15,10 +15,10 @@ metadata:
 spec:
   components:
   - podSets:
-    - podPath: template.spec.pytorchReplicaSpecs.Master.template
-      replicaPath: template.spec.pytorchReplicaSpecs.Master.replicas
-    - podPath: template.spec.pytorchReplicaSpecs.Worker.template
-      replicaPath: template.spec.pytorchReplicaSpecs.Worker.replicas
+    - replicas: 1
+      podPath: template.spec.pytorchReplicaSpecs.Master.template
+    - replicas: 1
+      podPath: template.spec.pytorchReplicaSpecs.Worker.template
     template:
       apiVersion: "kubeflow.org/v1"
       kind: PyTorchJob

--- a/test/e2e/appwrapper_test.go
+++ b/test/e2e/appwrapper_test.go
@@ -196,10 +196,6 @@ var _ = Describe("AppWrapper E2E Test", func() {
 			Expect(updateAppWrapper(ctx, awName, func(aw *workloadv1beta2.AppWrapper) {
 				aw.Spec.Components[0].PodSets[0].Replicas = ptr.To(int32(12))
 			})).ShouldNot(Succeed())
-
-			Expect(updateAppWrapper(ctx, awName, func(aw *workloadv1beta2.AppWrapper) {
-				aw.Spec.Components[0].PodSets[0].ReplicaPath = "bad"
-			})).ShouldNot(Succeed())
 		})
 	})
 

--- a/test/e2e/fixtures_test.go
+++ b/test/e2e/fixtures_test.go
@@ -25,6 +25,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/yaml"
 
 	workloadv1beta2 "github.com/project-codeflare/appwrapper/api/v1beta2"
@@ -158,7 +159,7 @@ func deployment(replicaCount int, milliCPU int64) workloadv1beta2.AppWrapperComp
 	jsonBytes, err := yaml.YAMLToJSON([]byte(yamlString))
 	Expect(err).NotTo(HaveOccurred())
 	return workloadv1beta2.AppWrapperComponent{
-		PodSets:  []workloadv1beta2.AppWrapperPodSet{{ReplicaPath: "template.spec.replicas", PodPath: "template.spec.template"}},
+		PodSets:  []workloadv1beta2.AppWrapperPodSet{{Replicas: ptr.To(int32(replicaCount)), PodPath: "template.spec.template"}},
 		Template: runtime.RawExtension{Raw: jsonBytes},
 	}
 }
@@ -198,7 +199,7 @@ func statefulset(replicaCount int, milliCPU int64) workloadv1beta2.AppWrapperCom
 	jsonBytes, err := yaml.YAMLToJSON([]byte(yamlString))
 	Expect(err).NotTo(HaveOccurred())
 	return workloadv1beta2.AppWrapperComponent{
-		PodSets:  []workloadv1beta2.AppWrapperPodSet{{ReplicaPath: "template.spec.replicas", PodPath: "template.spec.template"}},
+		PodSets:  []workloadv1beta2.AppWrapperPodSet{{Replicas: ptr.To(int32(replicaCount)), PodPath: "template.spec.template"}},
 		Template: runtime.RawExtension{Raw: jsonBytes},
 	}
 }
@@ -334,7 +335,7 @@ func pytorchjob(replicasWorker int, milliCPUWorker int64) workloadv1beta2.AppWra
 	Expect(err).NotTo(HaveOccurred())
 	return workloadv1beta2.AppWrapperComponent{
 		PodSets: []workloadv1beta2.AppWrapperPodSet{
-			{ReplicaPath: "template.spec.pytorchReplicaSpecs.Worker.replicas", PodPath: "template.spec.pytorchReplicaSpecs.Worker.template"},
+			{Replicas: ptr.To(int32(replicasWorker)), PodPath: "template.spec.pytorchReplicaSpecs.Worker.template"},
 		},
 		Template: runtime.RawExtension{Raw: jsonBytes},
 	}
@@ -390,7 +391,7 @@ func jobSet(replicasWorker int, milliCPUWorker int64) workloadv1beta2.AppWrapper
 	return workloadv1beta2.AppWrapperComponent{
 		PodSets: []workloadv1beta2.AppWrapperPodSet{
 			{PodPath: "template.spec.replicatedJobs[0].template.spec.template"},
-			{ReplicaPath: "template.spec.replicatedJobs[1].template.spec.parallelism", PodPath: "template.spec.replicatedJobs[1].template.spec.template"},
+			{Replicas: ptr.To(int32(replicasWorker)), PodPath: "template.spec.replicatedJobs[1].template.spec.template"},
 		},
 		Template: runtime.RawExtension{Raw: jsonBytes},
 	}


### PR DESCRIPTION
After discussion, we decided that `replicaPath` was not general enough to justify inclusion in the AppWrapper CRD. In particular, Jobs and JobSets cannot take advantage of `replicaPath` due to the complex logic involved in computing the replica counts for these kinds in Kueue.