### PR TITLE
Sanitize username for use as a label

### DIFF
--- a/internal/webhook/appwrapper_webhook.go
+++ b/internal/webhook/appwrapper_webhook.go
@@ -79,7 +79,8 @@ func (w *AppWrapperWebhook) Default(ctx context.Context, obj runtime.Object) err
 		return err
 	}
 	userInfo := request.UserInfo
-	aw.Labels = utilmaps.MergeKeepFirst(map[string]string{AppWrapperUsernameLabel: userInfo.Username, AppWrapperUserIDLabel: userInfo.UID}, aw.Labels)
+	username := utils.SanitizeLabel(userInfo.Username)
+	aw.Labels = utilmaps.MergeKeepFirst(map[string]string{AppWrapperUsernameLabel: username, AppWrapperUserIDLabel: userInfo.UID}, aw.Labels)
 	return nil
 }
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -18,6 +18,7 @@ package utils
 
 import (
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -345,4 +346,19 @@ func ValidatePodSets(obj *unstructured.Unstructured, podSets []workloadv1beta2.A
 	}
 
 	return nil
+}
+
+var labelRegex = regexp.MustCompile(`[^-_.\w]`)
+
+// SanitizeLabel sanitizes a string for use as a label
+func SanitizeLabel(label string) string {
+	// truncate to max length
+	if len(label) > 63 {
+		label = label[0:63]
+	}
+	// replace invalid characters with underscores
+	label = labelRegex.ReplaceAllString(label, "_")
+	// trim non-alphanumeric characters at both ends
+	label = strings.Trim(label, "-_.")
+	return label
 }


### PR DESCRIPTION
This PR rewrites usernames such as `IAM#tardieu@us.ibm.com` into valid labels by trimming to max length and eliminating invalid characters.