### PR TITLE
Add schedulerName option and injection logic

### DIFF
--- a/internal/controller/appwrapper/resource_management.go
+++ b/internal/controller/appwrapper/resource_management.go
@@ -51,6 +51,7 @@ func parseComponent(aw *workloadv1beta2.AppWrapper, raw []byte) (*unstructured.U
 	return obj, nil
 }
 
+//gocyclo:ignore
 func (r *AppWrapperReconciler) createComponent(ctx context.Context, aw *workloadv1beta2.AppWrapper, componentIdx int) (*unstructured.Unstructured, error, bool) {
 	component := aw.Spec.Components[componentIdx]
 	toMap := func(x interface{}) map[string]string {
@@ -143,6 +144,13 @@ func (r *AppWrapperReconciler) createComponent(ctx context.Context, aw *workload
 				tolerations = append(tolerations, addition)
 			}
 			spec["tolerations"] = tolerations
+		}
+
+		// Scheduler Name
+		if r.Config.SchedulerName != "" {
+			if existing, _ := spec["schedulerName"].(string); existing == "" {
+				spec["schedulerName"] = r.Config.SchedulerName
+			}
 		}
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -34,6 +34,7 @@ type AppWrapperConfig struct {
 	DisableChildAdmissionCtrl  bool                  `json:"disableChildAdmissionCtrl,omitempty"`
 	UserRBACAdmissionCheck     bool                  `json:"userRBACAdmissionCheck,omitempty"`
 	FaultTolerance             *FaultToleranceConfig `json:"faultTolerance,omitempty"`
+	SchedulerName              string                `json:"schedulerName,omitempty"`
 }
 
 type FaultToleranceConfig struct {
@@ -136,7 +137,7 @@ func NewCertManagementConfig(namespace string) *CertManagementConfig {
 	}
 }
 
-// NewControllerRuntimeConfig constructs a ControllerRuntimeConfig and filles in default values
+// NewControllerRuntimeConfig constructs a ControllerRuntimeConfig and fills in default values
 func NewControllerManagerConfig() *ControllerManagerConfig {
 	return &ControllerManagerConfig{
 		Metrics: MetricsConfiguration{


### PR DESCRIPTION
This PR adds a controller deployment option to automatically inject a `schedulerName` in pod template specs at resource creation time. This option makes it possible to use a secondary scheduler for all appwrapper components. The default behavior is unchanged (no `schedulerName` is injected). When the option is used, the `schedulerName` is only injected in pod template specs if a value is not already present. This makes it possible to explicitly ask for the `default-scheduler` even if the option is in use.