### PR TITLE
simplify configuration of handling of app wrappers without user-provided queue names

### DIFF
--- a/config/default/config.yaml
+++ b/config/default/config.yaml
@@ -6,7 +6,6 @@ data:
   config.yaml: |
     appwrapper:
       enableKueueIntegrations: true
-      manageJobsWithoutQueueName: true
     controllerManager:
       health:
         bindAddress: ":8081"

--- a/config/dev/config.yaml
+++ b/config/dev/config.yaml
@@ -6,7 +6,6 @@ data:
   config.yaml: |
     appwrapper:
       enableKueueIntegrations: true
-      manageJobsWithoutQueueName: true
     controllerManager:
       health:
         bindAddress: "localhost:0"

--- a/config/standalone/config.yaml
+++ b/config/standalone/config.yaml
@@ -6,7 +6,6 @@ data:
   config.yaml: |
     appwrapper:
       enableKueueIntegrations: false
-      manageJobsWithoutQueueName: false
     controllerManager:
       health:
         bindAddress: ":8081"

--- a/internal/webhook/appwrapper_webhook.go
+++ b/internal/webhook/appwrapper_webhook.go
@@ -72,13 +72,10 @@ func (w *AppWrapperWebhook) Default(ctx context.Context, obj runtime.Object) err
 
 	// Queue name and Suspend
 	if w.Config.EnableKueueIntegrations {
-		if w.Config.QueueName != "" && aw.Annotations[QueueNameLabel] == "" && aw.Labels[QueueNameLabel] == "" {
-			if aw.Labels == nil {
-				aw.Labels = map[string]string{}
-			}
-			aw.Labels[QueueNameLabel] = w.Config.QueueName
+		if w.Config.DefaultQueueName != "" {
+			aw.Labels = utilmaps.MergeKeepFirst(aw.Labels, map[string]string{QueueNameLabel: w.Config.DefaultQueueName})
 		}
-		jobframework.ApplyDefaultForSuspend((*wlc.AppWrapper)(aw), w.Config.ManageJobsWithoutQueueName)
+		jobframework.ApplyDefaultForSuspend((*wlc.AppWrapper)(aw), true)
 	}
 
 	// inject labels with user name and id

--- a/internal/webhook/suite_test.go
+++ b/internal/webhook/suite_test.go
@@ -160,7 +160,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	conf := config.NewAppWrapperConfig()
-	conf.QueueName = defaultQueueName // add default queue name
+	conf.DefaultQueueName = defaultQueueName // add default queue name
 	err = (&AppWrapperWebhook{Config: conf}).SetupWebhookWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred())
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -29,13 +29,12 @@ type OperatorConfig struct {
 }
 
 type AppWrapperConfig struct {
-	ManageJobsWithoutQueueName bool                  `json:"manageJobsWithoutQueueName,omitempty"`
-	EnableKueueIntegrations    bool                  `json:"enableKueueIntegrations,omitempty"`
-	DisableChildAdmissionCtrl  bool                  `json:"disableChildAdmissionCtrl,omitempty"`
-	UserRBACAdmissionCheck     bool                  `json:"userRBACAdmissionCheck,omitempty"`
-	FaultTolerance             *FaultToleranceConfig `json:"faultTolerance,omitempty"`
-	SchedulerName              string                `json:"schedulerName,omitempty"`
-	QueueName                  string                `json:"queueName,omitempty"`
+	EnableKueueIntegrations   bool                  `json:"enableKueueIntegrations,omitempty"`
+	DisableChildAdmissionCtrl bool                  `json:"disableChildAdmissionCtrl,omitempty"`
+	UserRBACAdmissionCheck    bool                  `json:"userRBACAdmissionCheck,omitempty"`
+	FaultTolerance            *FaultToleranceConfig `json:"faultTolerance,omitempty"`
+	SchedulerName             string                `json:"schedulerName,omitempty"`
+	DefaultQueueName          string                `json:"defaultQueueName,omitempty"`
 }
 
 type FaultToleranceConfig struct {
@@ -79,10 +78,9 @@ type HealthConfiguration struct {
 // NewAppWrapperConfig constructs an AppWrapperConfig and fills in default values
 func NewAppWrapperConfig() *AppWrapperConfig {
 	return &AppWrapperConfig{
-		ManageJobsWithoutQueueName: true,
-		EnableKueueIntegrations:    true,
-		DisableChildAdmissionCtrl:  false,
-		UserRBACAdmissionCheck:     true,
+		EnableKueueIntegrations:   true,
+		DisableChildAdmissionCtrl: false,
+		UserRBACAdmissionCheck:    true,
 		FaultTolerance: &FaultToleranceConfig{
 			AdmissionGracePeriod:        1 * time.Minute,
 			WarmupGracePeriod:           5 * time.Minute,

--- a/pkg/controller/setup.go
+++ b/pkg/controller/setup.go
@@ -42,7 +42,7 @@ func SetupControllers(mgr ctrl.Manager, awConfig *config.AppWrapperConfig) error
 		if err := workload.WorkloadReconciler(
 			mgr.GetClient(),
 			mgr.GetEventRecorderFor("kueue"),
-			jobframework.WithManageJobsWithoutQueueName(awConfig.ManageJobsWithoutQueueName),
+			jobframework.WithManageJobsWithoutQueueName(true),
 		).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("workload controller: %w", err)
 		}


### PR DESCRIPTION
The two configuration setting `manageJobsWithoutQueueNames` (boolean) and `defaultQueueName` (string) provided overlapping functionality (both provided a mechanism to force AppWrappers without user-provided queue names to be Suspended).   `defaultQueueName` is more useful/general so eliminate the boolean in favor of it.