### PR TITLE
ensure AppWrapper controller sets PodsReady condition on Workload (#180)

### DIFF
--- a/pkg/controller/setup.go
+++ b/pkg/controller/setup.go
@@ -33,6 +33,7 @@ import (
 	"github.com/project-codeflare/appwrapper/internal/webhook"
 	"github.com/project-codeflare/appwrapper/pkg/config"
 
+	"sigs.k8s.io/kueue/apis/config/v1beta1"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 )
 
@@ -43,6 +44,7 @@ func SetupControllers(mgr ctrl.Manager, awConfig *config.AppWrapperConfig) error
 			mgr.GetClient(),
 			mgr.GetEventRecorderFor("kueue"),
 			jobframework.WithManageJobsWithoutQueueName(true),
+			jobframework.WithWaitForPodsReady(&v1beta1.WaitForPodsReady{Enable: true}),
 		).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("workload controller: %w", err)
 		}


### PR DESCRIPTION
Need to conservatively set the WaitForPodsReady option to true so that the AppWrapper instance of Kueue's generic reconciller loop will set the PodsReady condition on the Workload instance when pods become ready.
