### PR TITLE
Flexible configuration of Kueue's GenericJob Reconciller

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -19,6 +19,8 @@ package config
 import (
 	"fmt"
 	"time"
+
+	"sigs.k8s.io/kueue/apis/config/v1beta1"
 )
 
 type OperatorConfig struct {
@@ -31,10 +33,17 @@ type OperatorConfig struct {
 type AppWrapperConfig struct {
 	EnableKueueIntegrations   bool                  `json:"enableKueueIntegrations,omitempty"`
 	DisableChildAdmissionCtrl bool                  `json:"disableChildAdmissionCtrl,omitempty"`
+	KueueJobReconciller       *KueueJobReconciller  `json:"kueueJobReconciller,omitempty"`
 	UserRBACAdmissionCheck    bool                  `json:"userRBACAdmissionCheck,omitempty"`
 	FaultTolerance            *FaultToleranceConfig `json:"faultTolerance,omitempty"`
 	SchedulerName             string                `json:"schedulerName,omitempty"`
 	DefaultQueueName          string                `json:"defaultQueueName,omitempty"`
+}
+
+type KueueJobReconciller struct {
+	ManageJobsWithoutQueueName bool                      `json:"manageJobsWithoutQueueName,omitempty"`
+	WaitForPodsReady           *v1beta1.WaitForPodsReady `json:"waitForPodsReady,omitempty"`
+	LabelKeysToCopy            []string                  `json:"labelKeysToCopy,omitempty"`
 }
 
 type FaultToleranceConfig struct {
@@ -80,7 +89,12 @@ func NewAppWrapperConfig() *AppWrapperConfig {
 	return &AppWrapperConfig{
 		EnableKueueIntegrations:   true,
 		DisableChildAdmissionCtrl: true,
-		UserRBACAdmissionCheck:    true,
+		KueueJobReconciller: &KueueJobReconciller{
+			ManageJobsWithoutQueueName: true,
+			WaitForPodsReady:           &v1beta1.WaitForPodsReady{Enable: true},
+			LabelKeysToCopy:            []string{},
+		},
+		UserRBACAdmissionCheck: true,
 		FaultTolerance: &FaultToleranceConfig{
 			AdmissionGracePeriod:        1 * time.Minute,
 			WarmupGracePeriod:           5 * time.Minute,

--- a/pkg/controller/setup.go
+++ b/pkg/controller/setup.go
@@ -33,7 +33,6 @@ import (
 	"github.com/project-codeflare/appwrapper/internal/webhook"
 	"github.com/project-codeflare/appwrapper/pkg/config"
 
-	"sigs.k8s.io/kueue/apis/config/v1beta1"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 )
 
@@ -43,8 +42,9 @@ func SetupControllers(mgr ctrl.Manager, awConfig *config.AppWrapperConfig) error
 		if err := workload.WorkloadReconciler(
 			mgr.GetClient(),
 			mgr.GetEventRecorderFor("kueue"),
-			jobframework.WithManageJobsWithoutQueueName(true),
-			jobframework.WithWaitForPodsReady(&v1beta1.WaitForPodsReady{Enable: true}),
+			jobframework.WithManageJobsWithoutQueueName(awConfig.KueueJobReconciller.ManageJobsWithoutQueueName),
+			jobframework.WithWaitForPodsReady(awConfig.KueueJobReconciller.WaitForPodsReady),
+			jobframework.WithLabelKeysToCopy(awConfig.KueueJobReconciller.LabelKeysToCopy),
 		).SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("workload controller: %w", err)
 		}


### PR DESCRIPTION
Expose all Kueue configuration options that are passed through to instances of the jobframework's GenericReconciller as configurable options in our AppWrapperConfig struct.
