### PR TITLE
Annotations to mark exit codes as being terminal (non-retryable)

### DIFF
--- a/api/v1beta2/appwrapper_types.go
+++ b/api/v1beta2/appwrapper_types.go
@@ -172,6 +172,8 @@ const (
 	ForcefulDeletionGracePeriodAnnotation  = "workload.codeflare.dev.appwrapper/forcefulDeletionGracePeriodDuration"
 	DeletionOnFailureGracePeriodAnnotation = "workload.codeflare.dev.appwrapper/deletionOnFailureGracePeriodDuration"
 	SuccessTTLAnnotation                   = "workload.codeflare.dev.appwrapper/successTTLDuration"
+	TerminalExitCodesAnnotation            = "workload.codeflare.dev.appwrapper/terminalExitCodes"
+	RetryableExitCodesAnnotation           = "workload.codeflare.dev.appwrapper/retryableExitCodes"
 )
 
 //+kubebuilder:object:root=true


### PR DESCRIPTION
Enable AppWrappers to be optionally annotated to indicate a subset of container exit codes that are terminal (disabling retry if they occur).
