### PR TITLE
emit an event when an unhealthy appwrapper is being reset

### DIFF
--- a/internal/controller/appwrapper/appwrapper_controller_test.go
+++ b/internal/controller/appwrapper/appwrapper_controller_test.go
@@ -24,6 +24,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
@@ -61,9 +62,10 @@ var _ = Describe("AppWrapper Controller", func() {
 		awConfig.FaultTolerance.RetryPausePeriod = 0 * time.Second
 		awConfig.FaultTolerance.RetryLimit = 0
 		awReconciler = &AppWrapperReconciler{
-			Client: k8sClient,
-			Scheme: k8sClient.Scheme(),
-			Config: awConfig,
+			Client:   k8sClient,
+			Recorder: &record.FakeRecorder{},
+			Scheme:   k8sClient.Scheme(),
+			Config:   awConfig,
 		}
 		kueuePodSets = (*workload.AppWrapper)(aw).PodSets()
 

--- a/pkg/controller/setup.go
+++ b/pkg/controller/setup.go
@@ -60,9 +60,10 @@ func SetupControllers(mgr ctrl.Manager, awConfig *config.AppWrapperConfig) error
 	}
 
 	if err := (&appwrapper.AppWrapperReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
-		Config: awConfig,
+		Client:   mgr.GetClient(),
+		Recorder: mgr.GetEventRecorderFor("appwrappers"),
+		Scheme:   mgr.GetScheme(),
+		Config:   awConfig,
 	}).SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("appwrapper controller: %w", err)
 	}


### PR DESCRIPTION
Since the detailed message for why the workload becomes unhealthy is lost when the condition is cleared on resuming, we should emit it as an event as well.
```
(base) dgrove@Dave's IBM Mac appwrapper % kubectl get events | grep  appwrapper/sample-failing-job
10m         Normal    CreatedWorkload        appwrapper/sample-failing-job                  Created Workload: default/appwrapper-sample-failing-job-4d7ed
10m         Normal    Started                appwrapper/sample-failing-job                  Admitted by clusterQueue cluster-queue
5m48s       Normal    CreatedWorkload        appwrapper/sample-failing-job                  Created Workload: default/appwrapper-sample-failing-job-9515b
5m48s       Normal    Started                appwrapper/sample-failing-job                  Admitted by clusterQueue cluster-queue
57s         Normal    Unhealthy              appwrapper/sample-failing-job                  FailedComponent: Found 1 failed components
52s         Normal    FinishedWorkload       appwrapper/sample-failing-job                  Workload 'default/appwrapper-sample-failing-job-9515b' is declared finished```
