### PR TITLE
Distinguish NoSchedule and NoExecute Autopilot labels

### DIFF
--- a/internal/controller/appwrapper/appwrapper_controller.go
+++ b/internal/controller/appwrapper/appwrapper_controller.go
@@ -521,7 +521,7 @@ func (r *AppWrapperReconciler) getPodStatus(ctx context.Context, aw *workloadv1b
 		return nil, err
 	}
 	summary := &podStatusSummary{expected: pc}
-	checkUnhealthyNodes := r.Config.Autopilot != nil && r.Config.Autopilot.MigrateImpactedWorkloads && !r.isAutopilotExempt(ctx, aw)
+	checkUnhealthyNodes := r.Config.Autopilot != nil && r.Config.Autopilot.MonitorNodes && !r.isAutopilotExempt(ctx, aw)
 
 	for _, pod := range pods.Items {
 		switch pod.Status.Phase {

--- a/internal/controller/appwrapper/node_health_monitor_test.go
+++ b/internal/controller/appwrapper/node_health_monitor_test.go
@@ -76,9 +76,9 @@ var _ = Describe("NodeMonitor Controller", func() {
 		By("Healthy cluster has no unhealthy nodes")
 		Expect(len(unhealthyNodes)).Should(Equal(0))
 
-		By("A newly labeled node is detected as unhealthy")
+		By("A node labeled EVICT is detected as unhealthy")
 		node := getNode(node1Name.Name)
-		node.Labels["autopilot.ibm.com/gpuhealth"] = "ERR"
+		node.Labels["autopilot.ibm.com/gpuhealth"] = "EVICT"
 		Expect(k8sClient.Update(ctx, node)).Should(Succeed())
 		_, err = nodeMonitor.Reconcile(ctx, reconcile.Request{NamespacedName: node1Name})
 		Expect(err).NotTo(HaveOccurred())
@@ -87,7 +87,6 @@ var _ = Describe("NodeMonitor Controller", func() {
 		Expect(len(unhealthyNodes)).Should(Equal(1))
 		Expect(unhealthyNodes).Should(HaveKey(node1Name.Name))
 		Expect(unhealthyNodes[node1Name.Name]).Should(HaveKey("nvidia.com/gpu"))
-		Expect(unhealthyNodes[node1Name.Name]["nvidia.com/gpu"].String()).Should(Equal("4"))
 
 		By("Repeated reconcile does not change map")
 		_, err = nodeMonitor.Reconcile(ctx, reconcile.Request{NamespacedName: node1Name})
@@ -97,10 +96,9 @@ var _ = Describe("NodeMonitor Controller", func() {
 		Expect(len(unhealthyNodes)).Should(Equal(1))
 		Expect(unhealthyNodes).Should(HaveKey(node1Name.Name))
 		Expect(unhealthyNodes[node1Name.Name]).Should(HaveKey("nvidia.com/gpu"))
-		Expect(unhealthyNodes[node1Name.Name]["nvidia.com/gpu"].String()).Should(Equal("4"))
 
-		By("Removing the autopilot label updates unhealthyNodes")
-		node.Labels["autopilot.ibm.com/gpuhealth"] = "OK"
+		By("Removing the EVICT label updates unhealthyNodes")
+		node.Labels["autopilot.ibm.com/gpuhealth"] = "ERR"
 		Expect(k8sClient.Update(ctx, node)).Should(Succeed())
 		_, err = nodeMonitor.Reconcile(ctx, reconcile.Request{NamespacedName: node1Name})
 		Expect(err).NotTo(HaveOccurred())
@@ -122,7 +120,7 @@ var _ = Describe("NodeMonitor Controller", func() {
 
 		// remove 4 gpus, lending limit should be 2
 		node1 := getNode(node1Name.Name)
-		node1.Labels["autopilot.ibm.com/gpuhealth"] = "ERR"
+		node1.Labels["autopilot.ibm.com/gpuhealth"] = "EVICT"
 		Expect(k8sClient.Update(ctx, node1)).Should(Succeed())
 		_, err = nodeMonitor.Reconcile(ctx, reconcile.Request{NamespacedName: node1Name})
 		Expect(err).NotTo(HaveOccurred())

--- a/internal/controller/appwrapper/resource_management.go
+++ b/internal/controller/appwrapper/resource_management.go
@@ -253,11 +253,11 @@ func (r *AppWrapperReconciler) createComponent(ctx context.Context, aw *workload
 		}
 
 		if r.Config.Autopilot != nil && r.Config.Autopilot.InjectAntiAffinities && !r.isAutopilotExempt(ctx, aw) {
-			toAdd := map[string]string{}
-			for resource, labels := range r.Config.Autopilot.ResourceUnhealthyConfig {
+			toAdd := map[string][]string{}
+			for resource, taints := range r.Config.Autopilot.ResourceTaints {
 				if hasResourceRequest(spec, resource) {
-					for k, v := range labels {
-						toAdd[k] = v
+					for _, taint := range taints {
+						toAdd[taint.Key] = append(toAdd[taint.Key], taint.Value)
 					}
 				}
 			}
@@ -265,7 +265,7 @@ func (r *AppWrapperReconciler) createComponent(ctx context.Context, aw *workload
 				nodeSelectors := []v1.NodeSelectorTerm{}
 				for k, v := range toAdd {
 					nodeSelectors = append(nodeSelectors, v1.NodeSelectorTerm{
-						MatchExpressions: []v1.NodeSelectorRequirement{{Operator: v1.NodeSelectorOpNotIn, Key: k, Values: []string{v}}},
+						MatchExpressions: []v1.NodeSelectorRequirement{{Operator: v1.NodeSelectorOpNotIn, Key: k, Values: v}},
 					})
 				}
 				if err := addNodeSelectorsToAffinity(spec, nodeSelectors); err != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"time"
 
+	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/kueue/apis/config/v1beta1"
 )
 
@@ -48,9 +49,9 @@ type KueueJobReconcillerConfig struct {
 }
 
 type AutopilotConfig struct {
-	InjectAntiAffinities     bool                         `json:"injectAntiAffinities,omitempty"`
-	MigrateImpactedWorkloads bool                         `json:"migrateImpactedWorkloads,omitempty"`
-	ResourceUnhealthyConfig  map[string]map[string]string `json:"resourceUnhealthyConfig,omitempty"`
+	InjectAntiAffinities     bool                  `json:"injectAntiAffinities,omitempty"`
+	MigrateImpactedWorkloads bool                  `json:"migrateImpactedWorkloads,omitempty"`
+	ResourceTaints           map[string][]v1.Taint `json:"resourceTaints,omitempty"`
 }
 
 type FaultToleranceConfig struct {
@@ -103,8 +104,10 @@ func NewAppWrapperConfig() *AppWrapperConfig {
 		Autopilot: &AutopilotConfig{
 			InjectAntiAffinities:     true,
 			MigrateImpactedWorkloads: true,
-			ResourceUnhealthyConfig: map[string]map[string]string{
-				"nvidia.com/gpu": {"autopilot.ibm.com/gpuhealth": "ERR"},
+			ResourceTaints: map[string][]v1.Taint{
+				"nvidia.com/gpu": {
+					{Key: "autopilot.ibm.com/gpuhealth", Value: "ERR", Effect: v1.TaintEffectNoSchedule},
+					{Key: "autopilot.ibm.com/gpuhealth", Value: "EVICT", Effect: v1.TaintEffectNoExecute}},
 			},
 		},
 		UserRBACAdmissionCheck: true,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -49,9 +49,9 @@ type KueueJobReconcillerConfig struct {
 }
 
 type AutopilotConfig struct {
-	InjectAntiAffinities     bool                  `json:"injectAntiAffinities,omitempty"`
-	MigrateImpactedWorkloads bool                  `json:"migrateImpactedWorkloads,omitempty"`
-	ResourceTaints           map[string][]v1.Taint `json:"resourceTaints,omitempty"`
+	InjectAntiAffinities bool                  `json:"injectAntiAffinities,omitempty"`
+	MonitorNodes         bool                  `json:"monitorNodes,omitempty"`
+	ResourceTaints       map[string][]v1.Taint `json:"resourceTaints,omitempty"`
 }
 
 type FaultToleranceConfig struct {
@@ -102,8 +102,8 @@ func NewAppWrapperConfig() *AppWrapperConfig {
 			LabelKeysToCopy:            []string{},
 		},
 		Autopilot: &AutopilotConfig{
-			InjectAntiAffinities:     true,
-			MigrateImpactedWorkloads: true,
+			InjectAntiAffinities: true,
+			MonitorNodes:         true,
 			ResourceTaints: map[string][]v1.Taint{
 				"nvidia.com/gpu": {
 					{Key: "autopilot.ibm.com/gpuhealth", Value: "ERR", Effect: v1.TaintEffectNoSchedule},

--- a/pkg/controller/setup.go
+++ b/pkg/controller/setup.go
@@ -50,7 +50,7 @@ func SetupControllers(mgr ctrl.Manager, awConfig *config.AppWrapperConfig) error
 		}
 	}
 
-	if awConfig.Autopilot != nil && awConfig.Autopilot.MigrateImpactedWorkloads {
+	if awConfig.Autopilot != nil && awConfig.Autopilot.MonitorNodes {
 		if err := (&appwrapper.NodeHealthMonitor{
 			Client: mgr.GetClient(),
 			Config: awConfig,

--- a/site/_pages/arch-fault-tolerance.md
+++ b/site/_pages/arch-fault-tolerance.md
@@ -167,14 +167,19 @@ Autopilot configuration used by the controller is:
 autopilot:
   injectAntiAffinities: true
   migrateImpactedWorkloads: true
-  resourceUnhealthyConfig:
+  resourceTaints:
     nvidia.com/gpu:
-      autopilot.ibm.com/gpuhealth: ERR
+    - key: autopilot.ibm.com/gpuhealth
+      value: ERR
+      effect: NoSchedule
+    - key: autopilot.ibm.com/gpuhealth
+      value: EVICT
+      effect: NoExecute
 ```
 
-The `resourceUnhealthyConfig` is a map from resource names to labels. For this example
+The `resourceTaints` is a map from resource names to taints. For this example
 configuration, for exactly those Pods that have a non-zero resource request for
-`nvidia.com/gpu`, the AppWrapper controller will automatically inject the stanze below
+`nvidia.com/gpu`, the AppWrapper controller will automatically inject the stanza below
 into the `affinity` portion of their Spec.
 ```yaml
       nodeAffinity:
@@ -185,4 +190,5 @@ into the `affinity` portion of their Spec.
               operator: NotIn
               values:
               - ERR
+              - EVICT
 ```

--- a/site/_pages/arch-fault-tolerance.md
+++ b/site/_pages/arch-fault-tolerance.md
@@ -166,7 +166,7 @@ Autopilot configuration used by the controller is:
 ```yaml
 autopilot:
   injectAntiAffinities: true
-  migrateImpactedWorkloads: true
+  monitorNodes: true
   resourceTaints:
     nvidia.com/gpu:
     - key: autopilot.ibm.com/gpuhealth

--- a/test/e2e/appwrapper_test.go
+++ b/test/e2e/appwrapper_test.go
@@ -321,7 +321,7 @@ var _ = Describe("AppWrapper E2E Test", func() {
 				err := updateNode(ctx, nodeName, func(n *v1.Node) { delete(n.Labels, "autopilot.ibm.com/gpuhealth") })
 				Expect(err).ShouldNot(HaveOccurred())
 			})
-			err = updateNode(ctx, nodeName, func(n *v1.Node) { n.Labels["autopilot.ibm.com/gpuhealth"] = "ERR" })
+			err = updateNode(ctx, nodeName, func(n *v1.Node) { n.Labels["autopilot.ibm.com/gpuhealth"] = "EVICT" })
 			Expect(err).ShouldNot(HaveOccurred())
 			By("workload is reset")
 			Eventually(AppWrapperPhase(ctx, aw), 120*time.Second).Should(Equal(workloadv1beta2.AppWrapperResetting))


### PR DESCRIPTION
This PR introduces a distinction between `NoSchedule` and `NoExecute` Autopilot labels, which are configured using the syntax of taints:
```
     autopilot:
        injectAntiAffinities: true
        monitorNodes: true
        resourceTaints:
          nvidia.com/gpu:
          - key: autopilot.ibm.com/gpuhealth
            value: EVICT
            effect: NoExecute
          - key: autopilot.ibm.com/gpuhealth
            value: ERR
            effect: NoSchedule
 ```

When a resource on a node is labeled with effect `NoSchedule` the node capacity for this resource is subtracted from the lending limit on the slack cluster queue, but workloads already running on the node are not impacted.

When a resource on a node is labeled with effect `NoExecute` the lending limit is reduced and, in addition, workloads running on the node and using the resource are reset.

This PR also adjusts lending limits for cordoned nodes.