### PR TITLE
Get dev mode (make run) working again

### DIFF
--- a/internal/webhook/appwrapper_webhook.go
+++ b/internal/webhook/appwrapper_webhook.go
@@ -77,7 +77,7 @@ func (w *AppWrapperWebhook) Default(ctx context.Context, obj runtime.Object) err
 		if w.Config.DefaultQueueName != "" {
 			aw.Labels = utilmaps.MergeKeepFirst(aw.Labels, map[string]string{QueueNameLabel: w.Config.DefaultQueueName})
 		}
-		jobframework.ApplyDefaultForSuspend((*wlc.AppWrapper)(aw), true)
+		jobframework.ApplyDefaultForSuspend((*wlc.AppWrapper)(aw), w.Config.KueueJobReconciller.ManageJobsWithoutQueueName)
 	}
 
 	// inject labels with user name and id


### PR DESCRIPTION
When running without webhooks, apply defaults that are normally set by the webhook during the Empty==>Suspended transition.
