### PR TITLE
autopilot: add TESTING NoSchedule taint

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -107,6 +107,7 @@ func NewAppWrapperConfig() *AppWrapperConfig {
 			ResourceTaints: map[string][]v1.Taint{
 				"nvidia.com/gpu": {
 					{Key: "autopilot.ibm.com/gpuhealth", Value: "ERR", Effect: v1.TaintEffectNoSchedule},
+					{Key: "autopilot.ibm.com/gpuhealth", Value: "TESTING", Effect: v1.TaintEffectNoSchedule},
 					{Key: "autopilot.ibm.com/gpuhealth", Value: "EVICT", Effect: v1.TaintEffectNoExecute}},
 			},
 		},


### PR DESCRIPTION
Add a taint with a NoSchedule effect that can be used by autopilot to indicate that an intrusive dgemm test is being performed on a Node.
