### PR TITLE
Redesign node monitoring to account for Node deletion

### DIFF
--- a/internal/controller/appwrapper/appwrapper_controller.go
+++ b/internal/controller/appwrapper/appwrapper_controller.go
@@ -559,7 +559,7 @@ func (r *AppWrapperReconciler) getPodStatus(ctx context.Context, aw *workloadv1b
 			if pod.DeletionTimestamp.IsZero() {
 				summary.running += 1
 				if checkNoExecuteNodes {
-					noExecuteNodesMutex.RLock() // BEGIN CRITICAL SECTION
+					nodeInfoMutex.RLock() // BEGIN CRITICAL SECTION
 					if len(noExecuteNodes) > 0 {
 						if resources, ok := noExecuteNodes[pod.Spec.NodeName]; ok {
 							for badResource := range resources {
@@ -584,7 +584,7 @@ func (r *AppWrapperReconciler) getPodStatus(ctx context.Context, aw *workloadv1b
 							}
 						}
 					}
-					noExecuteNodesMutex.RUnlock() // END CRITICAL SECTION
+					nodeInfoMutex.RUnlock() // END CRITICAL SECTION
 				}
 			}
 		case v1.PodSucceeded:

--- a/internal/controller/appwrapper/appwrapper_controller.go
+++ b/internal/controller/appwrapper/appwrapper_controller.go
@@ -559,7 +559,7 @@ func (r *AppWrapperReconciler) getPodStatus(ctx context.Context, aw *workloadv1b
 			if pod.DeletionTimestamp.IsZero() {
 				summary.running += 1
 				if checkNoExecuteNodes {
-					nodeInfoMutex.RLock() // BEGIN CRITICAL SECTION
+					noExecuteNodesMutex.RLock() // BEGIN CRITICAL SECTION
 					if len(noExecuteNodes) > 0 {
 						if resources, ok := noExecuteNodes[pod.Spec.NodeName]; ok {
 							for badResource := range resources {
@@ -584,7 +584,7 @@ func (r *AppWrapperReconciler) getPodStatus(ctx context.Context, aw *workloadv1b
 							}
 						}
 					}
-					nodeInfoMutex.RUnlock() // END CRITICAL SECTION
+					noExecuteNodesMutex.RUnlock() // END CRITICAL SECTION
 				}
 			}
 		case v1.PodSucceeded:

--- a/internal/controller/appwrapper/node_health_monitor.go
+++ b/internal/controller/appwrapper/node_health_monitor.go
@@ -48,14 +48,14 @@ type NodeHealthMonitor struct {
 }
 
 var (
-	// nodeInfoMutex syncnornized writes by NodeHealthMonitor with reads from AppWrapperReconciler and SlackClusterQueueMonitor
+	// nodeInfoMutex synchronizes writes by NodeHealthMonitor with reads from AppWrapperReconciler and SlackClusterQueueMonitor
 	nodeInfoMutex sync.RWMutex
 
 	// noExecuteNodes is a mapping from Node names to resources with an Autopilot NoExecute taint
 	noExecuteNodes = make(map[string]sets.Set[string])
 
 	// noScheduleNodes is a mapping from Node names to ResourceLists of unschedulable resources.
-	// A resource may be unscheduable either because:
+	// A resource may be unschedulable either because:
 	//  (a) the Node is cordoned (node.Spec.Unschedulable is true) or
 	//  (b) Autopilot has labeled the Node with a NoExecute or NoSchedule taint for the resource.
 	noScheduleNodes = make(map[string]v1.ResourceList)
@@ -91,7 +91,6 @@ func (r *NodeHealthMonitor) Reconcile(ctx context.Context, req ctrl.Request) (ct
 func (r *NodeHealthMonitor) triggerSlackCQMonitor() {
 	if r.Config.SlackQueueName != "" {
 		select {
-		// Trigger dispatch by means of "*/*" request
 		case r.Events <- event.GenericEvent{Object: &metav1.PartialObjectMetadata{ObjectMeta: metav1.ObjectMeta{Name: dispatchEventName}}}:
 		default:
 			// do not block if event is already in channel
@@ -99,7 +98,7 @@ func (r *NodeHealthMonitor) triggerSlackCQMonitor() {
 	}
 }
 
-// update for the deletion of nodeName
+// update noExecuteNodes and noScheduleNodes for the deletion of nodeName
 func (r *NodeHealthMonitor) updateForNodeDeletion(ctx context.Context, nodeName string) {
 	if _, ok := noExecuteNodes[nodeName]; ok {
 		nodeInfoMutex.Lock() // BEGIN CRITICAL SECTION

--- a/internal/controller/appwrapper/node_health_monitor_test.go
+++ b/internal/controller/appwrapper/node_health_monitor_test.go
@@ -30,9 +30,9 @@ import (
 
 var _ = Describe("NodeMonitor Controller", func() {
 	var slackQueueName = "fake-queue"
+	var dispatch = types.NamespacedName{Name: slackQueueName}
 	var node1Name = types.NamespacedName{Name: "fake-node-1"}
 	var node2Name = types.NamespacedName{Name: "fake-node-2"}
-	var dispatch = types.NamespacedName{Name: dispatchEventName}
 	var nodeMonitor *NodeHealthMonitor
 	var cqMonitor *SlackClusterQueueMonitor
 	nodeGPUs := v1.ResourceList{v1.ResourceName("nvidia.com/gpu"): resource.MustParse("4")}

--- a/internal/controller/appwrapper/slackcq_monitor.go
+++ b/internal/controller/appwrapper/slackcq_monitor.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2024 IBM Corporation.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package appwrapper
+
+import (
+	"context"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+
+	"github.com/project-codeflare/appwrapper/pkg/config"
+)
+
+// SlackClusterQueueMonitor uses the information gathered by the NodeHealthMonitor to
+// adjust the lending limitLimits of a designated slack ClusterQueue
+type SlackClusterQueueMonitor struct {
+	client.Client
+	Config *config.AppWrapperConfig
+	Events chan event.GenericEvent // event channel for NodeHealthMonitor to trigger SlackClusterQueueMonitor
+}
+
+// permission to watch, get and update clusterqueues
+//+kubebuilder:rbac:groups=kueue.x-k8s.io,resources=clusterqueues,verbs=get;list;watch;update;patch
+
+func (r *SlackClusterQueueMonitor) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	if !(req.Name == dispatchEventName || req.Name == r.Config.SlackQueueName) {
+		return ctrl.Result{}, nil
+	}
+
+	cq := &kueue.ClusterQueue{}
+	if err := r.Get(ctx, types.NamespacedName{Name: r.Config.SlackQueueName}, cq); err != nil {
+		if errors.IsNotFound(err) {
+			return ctrl.Result{}, nil // give up if slack cluster queue is not defined
+		}
+		return ctrl.Result{}, err
+	}
+
+	// Compute the total quantities of unschedulable resources
+	unschedulableQuantities := map[v1.ResourceName]*resource.Quantity{}
+	nodeInfoMutex.RLock() // BEGIN CRITICAL SECTION
+	for _, quantities := range noScheduleNodes {
+		for resourceName, quantity := range quantities {
+			if !quantity.IsZero() {
+				if unschedulableQuantities[resourceName] == nil {
+					unschedulableQuantities[resourceName] = ptr.To(quantity)
+				} else {
+					unschedulableQuantities[resourceName].Add(quantity)
+				}
+			}
+		}
+	}
+	nodeInfoMutex.RUnlock() // END CRITICAL SECTION
+
+	// enforce lending limits on 1st flavor of 1st resource group
+	resources := cq.Spec.ResourceGroups[0].Flavors[0].Resources
+	limitsChanged := false
+	for i, quota := range resources {
+		var lendingLimit *resource.Quantity
+		if unschedulableQuantity := unschedulableQuantities[quota.Name]; unschedulableQuantity != nil {
+			if quota.NominalQuota.Cmp(*unschedulableQuantity) > 0 {
+				lendingLimit = ptr.To(quota.NominalQuota)
+				lendingLimit.Sub(*unschedulableQuantity)
+			} else {
+				lendingLimit = resource.NewQuantity(0, resource.DecimalSI)
+			}
+		}
+		if quota.LendingLimit == nil && lendingLimit != nil ||
+			quota.LendingLimit != nil && lendingLimit == nil ||
+			quota.LendingLimit != nil && lendingLimit != nil && quota.LendingLimit.Cmp(*lendingLimit) != 0 {
+			limitsChanged = true
+			resources[i].LendingLimit = lendingLimit
+		}
+	}
+
+	// update lending limits
+	if limitsChanged {
+		err := r.Update(ctx, cq)
+		if err == nil {
+			log.FromContext(ctx).Info("Updated lending limits", "Resources", resources)
+			return ctrl.Result{}, nil
+		} else if errors.IsConflict(err) {
+			return ctrl.Result{Requeue: true}, nil
+		} else {
+			return ctrl.Result{}, err
+		}
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *SlackClusterQueueMonitor) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		Watches(&kueue.ClusterQueue{}, &handler.EnqueueRequestForObject{}).
+		WatchesRawSource(&source.Channel{Source: r.Events}, &handler.EnqueueRequestForObject{}).
+		Named("SlackClusterQueueMonitor").
+		Complete(r)
+}

--- a/internal/controller/appwrapper/slackcq_monitor.go
+++ b/internal/controller/appwrapper/slackcq_monitor.go
@@ -48,7 +48,7 @@ type SlackClusterQueueMonitor struct {
 //+kubebuilder:rbac:groups=kueue.x-k8s.io,resources=clusterqueues,verbs=get;list;watch;update;patch
 
 func (r *SlackClusterQueueMonitor) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	if !(req.Name == dispatchEventName || req.Name == r.Config.SlackQueueName) {
+	if req.Name != r.Config.SlackQueueName {
 		return ctrl.Result{}, nil
 	}
 
@@ -62,7 +62,7 @@ func (r *SlackClusterQueueMonitor) Reconcile(ctx context.Context, req ctrl.Reque
 
 	// Compute the total quantities of unschedulable resources
 	unschedulableQuantities := map[v1.ResourceName]*resource.Quantity{}
-	nodeInfoMutex.RLock() // BEGIN CRITICAL SECTION
+	noScheduleNodesMutex.RLock() // BEGIN CRITICAL SECTION
 	for _, quantities := range noScheduleNodes {
 		for resourceName, quantity := range quantities {
 			if !quantity.IsZero() {
@@ -74,7 +74,7 @@ func (r *SlackClusterQueueMonitor) Reconcile(ctx context.Context, req ctrl.Reque
 			}
 		}
 	}
-	nodeInfoMutex.RUnlock() // END CRITICAL SECTION
+	noScheduleNodesMutex.RUnlock() // END CRITICAL SECTION
 
 	// enforce lending limits on 1st flavor of 1st resource group
 	resources := cq.Spec.ResourceGroups[0].Flavors[0].Resources


### PR DESCRIPTION
1. Split node monitoring into two reconcilers, one to monitor Nodes and one to monitor and update the designated slack ClusterQueue.
2. Remove entries from in memory caches when a Node is deleted.
3. Watch slack cluster queue to be able to react to changes in nominalQuotas and adjust lendingLimits accordingly.

Fixes #252.
