### PR TITLE
Revert "add initial grace period before triggering a failure due to missing components (#273)

### DIFF
--- a/test/e2e/appwrapper_test.go
+++ b/test/e2e/appwrapper_test.go
@@ -297,13 +297,8 @@ var _ = Describe("AppWrapper E2E Test", func() {
 			Expect(aw.Status.Retries).Should(Equal(int32(2)))
 		})
 
-		It("Deleting a Running Component yields a failed AppWrapper", Label("slow"), func() {
-			aw := toAppWrapper(pytorchjob(2, 500))
-			if aw.Annotations == nil {
-				aw.Annotations = make(map[string]string)
-			}
-			aw.Annotations[workloadv1beta2.AdmissionGracePeriodDurationAnnotation] = "5s"
-			Expect(getClient(ctx).Create(ctx, aw)).To(Succeed())
+		It("Deleting a Running Component yields a failed AppWrapper", func() {
+			aw := createAppWrapper(ctx, pytorchjob(2, 500))
 			appwrappers = append(appwrappers, aw)
 			Eventually(AppWrapperPhase(ctx, aw), 60*time.Second).Should(Equal(workloadv1beta2.AppWrapperRunning))
 			aw = getAppWrapper(ctx, types.NamespacedName{Name: aw.Name, Namespace: aw.Namespace})


### PR DESCRIPTION
This reverts commit 256dbab67498a091fbdf8e787ec5010efd05b521.

The change was not necessary.  

The root cause of the observed problem was a misconfiguration of the controller runtime
cache in the codeflare operator.
