### PR TITLE
disabling visibilityOnDemand in Kueue blocks namespace deletion

### DIFF
--- a/hack/kueue-config/kustomization.yaml
+++ b/hack/kueue-config/kustomization.yaml
@@ -37,8 +37,4 @@ patches:
   patch: |
     - op: add
       path: /spec/template/spec/containers/0/args/-
-      value: "--feature-gates=VisibilityOnDemand=false"
-# DEBUG support; uncomment this patch to boost Kueue log levels
-#    - op: add
-#      path: /spec/template/spec/containers/0/args/-
-#      value: "--zap-log-level=5"
+      value: "--zap-log-level=2"


### PR DESCRIPTION
A variant of Kueue bug https://github.com/kubernetes-sigs/kueue/issues/1769 is back in Kueue 0.10. 

https://github.com/kubernetes-sigs/kueue/pull/3908 removes the need to disable the feature to avoid spurious log messages about VAP, so let's just accept the spurious error logs about VAP for now. 