### PR TITLE
move appwrapper finalizer injection from defaulting webhook to controller

### DIFF
--- a/internal/controller/appwrapper/appwrapper_controller_test.go
+++ b/internal/controller/appwrapper/appwrapper_controller_test.go
@@ -81,7 +81,6 @@ var _ = Describe("AppWrapper Controller", func() {
 
 		aw = getAppWrapper(awName)
 		Expect(aw.Status.Phase).Should(Equal(workloadv1beta2.AppWrapperSuspended))
-		Expect(controllerutil.ContainsFinalizer(aw, AppWrapperFinalizer)).Should(BeTrue())
 
 		By("Updating aw.Spec by invoking RunWithPodSetsInfo")
 		Expect((*workload.AppWrapper)(aw).RunWithPodSetsInfo([]podset.PodSetInfo{markerPodSet, markerPodSet})).To(Succeed())
@@ -94,6 +93,7 @@ var _ = Describe("AppWrapper Controller", func() {
 
 		aw = getAppWrapper(awName)
 		Expect(aw.Status.Phase).Should(Equal(workloadv1beta2.AppWrapperResuming))
+		Expect(controllerutil.ContainsFinalizer(aw, AppWrapperFinalizer)).Should(BeTrue())
 		Expect(meta.IsStatusConditionTrue(aw.Status.Conditions, string(workloadv1beta2.ResourcesDeployed))).Should(BeTrue())
 		Expect(meta.IsStatusConditionTrue(aw.Status.Conditions, string(workloadv1beta2.QuotaReserved))).Should(BeTrue())
 		Expect((*workload.AppWrapper)(aw).IsActive()).Should(BeTrue())


### PR DESCRIPTION
defaulting webhooks can run in any order, therefore we can't rely using the value of managedBy seen by our defaulter to figure out whether or not we should add the appwrapper finalizer.

To reduce reconciliation conflicts with Kueue, defer adding the finalizer until we are taking the Suspended to Resuming transition (which will only happen after Kueue's workload controller successfully updates Spec.Suspend).
