### PR TITLE
reduce devmode tests in CI

### DIFF
--- a/.github/workflows/CI-devmode.yaml
+++ b/.github/workflows/CI-devmode.yaml
@@ -49,9 +49,6 @@ jobs:
     - name: Create and configure cluster
       run: ./hack/create-test-cluster.sh
 
-    - name: Deploy Kueue
-      run: ./hack/deploy-kueue.sh
-
     - name: Install CRDs
       run: |
         make install -e GIT_BRANCH=${{ env.GIT_BRANCH }} TAG=${{ env.GIT_BRANCH }}-${{ env.TAG }}

--- a/config/dev/config.yaml
+++ b/config/dev/config.yaml
@@ -5,7 +5,7 @@ metadata:
 data:
   config.yaml: |
     appwrapper:
-      enableKueueIntegrations: true
+      enableKueueIntegrations: false
     controllerManager:
       health:
         bindAddress: "localhost:0"

--- a/docs/release_instructions.md
+++ b/docs/release_instructions.md
@@ -16,8 +16,7 @@ will:
    + create a [GitHub release](https://github.com/project-codeflare/appwrapper/releases) that contains the install.yaml
 
 4. Update the kustomization.yaml files in MLBatch to refer to the new release:
-  + setup.k8s-v1.27/appwrapper/kustomization.yaml
-  + setup.k8s-v1.30/appwrapper/kustomization.yaml
+  + setup.k8s/appwrapper/kustomization.yaml
 
 4. To workaround back level go versions in ODH, we also maintain a
    codeflare-releases branch.  After making a release, merge main

--- a/hack/run-dev-mode-tests.sh
+++ b/hack/run-dev-mode-tests.sh
@@ -35,7 +35,7 @@ run () {
 }
 
 NAMESPACE=dev go run ./cmd/main.go &
-run $! go run github.com/onsi/ginkgo/v2/ginkgo -v -fail-fast --procs 1 -timeout 130m --label-filter=Kueue ./test/e2e
+run $! go run github.com/onsi/ginkgo/v2/ginkgo -v -fail-fast --procs 1 -timeout 130m --label-filter=Standalone ./test/e2e
 
 RC=$?
 if [ ${RC} -eq 0 ]


### PR DESCRIPTION
after #307  we're not faking the webhook in the controller, so the devmode tests can't assume that Suspend is automatically being set to true. 
