### PR TITLE
Confirm a missing component with an uncached read before failing

### DIFF
--- a/internal/controller/appwrapper/appwrapper_controller.go
+++ b/internal/controller/appwrapper/appwrapper_controller.go
@@ -53,9 +53,13 @@ const (
 // AppWrapperReconciler reconciles an appwrapper
 type AppWrapperReconciler struct {
 	client.Client
-	Recorder events.EventRecorder
-	Scheme   *runtime.Scheme
-	Config   *config.AppWrapperConfig
+	// APIReader performs uncached reads directly against the API server. It is used to
+	// confirm the absence of a component before failing an AppWrapper, because the
+	// cache-backed Client may not yet reflect a component this controller just created.
+	APIReader client.Reader
+	Recorder  events.EventRecorder
+	Scheme    *runtime.Scheme
+	Config    *config.AppWrapperConfig
 }
 
 type podStatusSummary struct {
@@ -249,10 +253,30 @@ func (r *AppWrapperReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		}
 
 		// Gather status information at the Component and Pod level.
-		compStatus, err := r.getComponentStatus(ctx, aw)
+		compStatus, err := r.getComponentStatus(ctx, r.Client, aw)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
+
+		// A missing component is a terminal verdict: it fails the AppWrapper with no grace
+		// period and no retry.  The cache-backed Client is not a sound basis for that verdict
+		// because it can lag the API server -- notably right after this controller created the
+		// component itself, or while a freshly started informer is still catching up.  Confirm
+		// the absence with an uncached read before condemning the AppWrapper.
+		if compStatus.deployed != compStatus.expected {
+			compStatus, err = r.getComponentStatus(ctx, r.apiReader(), aw)
+			if err != nil {
+				return ctrl.Result{}, err
+			}
+			if compStatus.deployed != compStatus.expected {
+				log.FromContext(ctx).Info("Missing component confirmed by uncached read",
+					"deployed", compStatus.deployed, "expected", compStatus.expected)
+			} else {
+				log.FromContext(ctx).V(2).Info("Stale cache reported a missing component; uncached read found all components",
+					"expected", compStatus.expected)
+			}
+		}
+
 		podStatus, err := r.getPodStatus(ctx, aw)
 		if err != nil {
 			return ctrl.Result{}, err
@@ -625,7 +649,7 @@ func (r *AppWrapperReconciler) getPodStatus(ctx context.Context, aw *awv1beta2.A
 }
 
 //gocyclo:ignore
-func (r *AppWrapperReconciler) getComponentStatus(ctx context.Context, aw *awv1beta2.AppWrapper) (*componentStatusSummary, error) {
+func (r *AppWrapperReconciler) getComponentStatus(ctx context.Context, reader client.Reader, aw *awv1beta2.AppWrapper) (*componentStatusSummary, error) {
 	summary := &componentStatusSummary{expected: int32(len(aw.Status.ComponentStatus))}
 
 	for componentIdx := range aw.Status.ComponentStatus {
@@ -634,7 +658,7 @@ func (r *AppWrapperReconciler) getComponentStatus(ctx context.Context, aw *awv1b
 
 		case "batch/v1:Job":
 			obj := &batchv1.Job{}
-			if err := r.Get(ctx, types.NamespacedName{Name: cs.Name, Namespace: aw.Namespace}, obj); err == nil {
+			if err := reader.Get(ctx, types.NamespacedName{Name: cs.Name, Namespace: aw.Namespace}, obj); err == nil {
 				if obj.GetDeletionTimestamp().IsZero() {
 					summary.deployed += 1
 
@@ -654,7 +678,7 @@ func (r *AppWrapperReconciler) getComponentStatus(ctx context.Context, aw *awv1b
 			obj := &unstructured.Unstructured{}
 			obj.SetAPIVersion(cs.APIVersion)
 			obj.SetKind(cs.Kind)
-			if err := r.Get(ctx, types.NamespacedName{Name: cs.Name, Namespace: aw.Namespace}, obj); err == nil {
+			if err := reader.Get(ctx, types.NamespacedName{Name: cs.Name, Namespace: aw.Namespace}, obj); err == nil {
 				if obj.GetDeletionTimestamp().IsZero() {
 					summary.deployed += 1
 
@@ -689,7 +713,7 @@ func (r *AppWrapperReconciler) getComponentStatus(ctx context.Context, aw *awv1b
 			obj := &unstructured.Unstructured{}
 			obj.SetAPIVersion(cs.APIVersion)
 			obj.SetKind(cs.Kind)
-			if err := r.Get(ctx, types.NamespacedName{Name: cs.Name, Namespace: aw.Namespace}, obj); err == nil {
+			if err := reader.Get(ctx, types.NamespacedName{Name: cs.Name, Namespace: aw.Namespace}, obj); err == nil {
 				if obj.GetDeletionTimestamp().IsZero() {
 					summary.deployed += 1
 
@@ -719,7 +743,7 @@ func (r *AppWrapperReconciler) getComponentStatus(ctx context.Context, aw *awv1b
 			obj := &unstructured.Unstructured{}
 			obj.SetAPIVersion(cs.APIVersion)
 			obj.SetKind(cs.Kind)
-			if err := r.Get(ctx, types.NamespacedName{Name: cs.Name, Namespace: aw.Namespace}, obj); err == nil {
+			if err := reader.Get(ctx, types.NamespacedName{Name: cs.Name, Namespace: aw.Namespace}, obj); err == nil {
 				if obj.GetDeletionTimestamp().IsZero() {
 					summary.deployed += 1
 
@@ -746,7 +770,7 @@ func (r *AppWrapperReconciler) getComponentStatus(ctx context.Context, aw *awv1b
 
 		default:
 			obj := &metav1.PartialObjectMetadata{TypeMeta: metav1.TypeMeta{Kind: cs.Kind, APIVersion: cs.APIVersion}}
-			if err := r.Get(ctx, types.NamespacedName{Name: cs.Name, Namespace: aw.Namespace}, obj); err == nil {
+			if err := reader.Get(ctx, types.NamespacedName{Name: cs.Name, Namespace: aw.Namespace}, obj); err == nil {
 				if obj.GetDeletionTimestamp().IsZero() {
 					summary.deployed += 1
 				}
@@ -916,6 +940,15 @@ func (r *AppWrapperReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(&v1.Pod{}, handler.EnqueueRequestsFromMapFunc(r.podMapFunc)).
 		Named(awv1beta2.AppWrapperKind).
 		Complete(r)
+}
+
+// apiReader returns a Reader that bypasses the controller-runtime cache.
+// It falls back to the cached Client if no APIReader was injected.
+func (r *AppWrapperReconciler) apiReader() client.Reader {
+	if r.APIReader != nil {
+		return r.APIReader
+	}
+	return r.Client
 }
 
 // copyForStatusPatch returns an AppWrapper with an empty Spec and a DeepCopy of orig's Status for use in a subsequent Status().Patch(...) call

--- a/internal/controller/appwrapper/appwrapper_controller_test.go
+++ b/internal/controller/appwrapper/appwrapper_controller_test.go
@@ -65,10 +65,11 @@ var _ = Describe("AppWrapper Controller", func() {
 		awConfig.Autopilot.ResourceTaints["nvidia.com/gpu"] = append(awConfig.Autopilot.ResourceTaints["nvidia.com/gpu"], v1.Taint{Key: "extra2", Value: "test2", Effect: v1.TaintEffectPreferNoSchedule})
 
 		awReconciler = &AppWrapperReconciler{
-			Client:   k8sClient,
-			Recorder: &events.FakeRecorder{},
-			Scheme:   k8sClient.Scheme(),
-			Config:   awConfig,
+			Client:    k8sClient,
+			APIReader: k8sClient,
+			Recorder:  &events.FakeRecorder{},
+			Scheme:    k8sClient.Scheme(),
+			Config:    awConfig,
 		}
 
 		By("Reconciling: Empty -> Suspended")
@@ -215,6 +216,44 @@ var _ = Describe("AppWrapper Controller", func() {
 		podStatus, err := awReconciler.getPodStatus(ctx, aw)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(podStatus.failed + podStatus.succeeded + podStatus.running + podStatus.pending).Should(Equal(int32(0)))
+	})
+
+	It("A stale cache must not be treated as a missing component", func() {
+		advanceToResuming(pod(100, 1, true), pod(100, 0, false))
+		beginRunning()
+
+		By("Blinding the reconciler's cached client to the deployed components")
+		awReconciler.Client = &cacheBlindToPods{Client: k8sClient}
+		defer func() { awReconciler.Client = k8sClient }()
+
+		By("Reconciling: Running -> Running (the uncached read still finds every component)")
+		_, err := awReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: awName})
+		Expect(err).NotTo(HaveOccurred())
+
+		aw := getAppWrapper(awName)
+		Expect(aw.Status.Phase).Should(Equal(awv1beta2.AppWrapperRunning))
+		Expect(meta.IsStatusConditionTrue(aw.Status.Conditions, string(awv1beta2.Unhealthy))).Should(BeFalse())
+	})
+
+	It("A genuinely deleted component still fails the AppWrapper", func() {
+		advanceToResuming(pod(100, 1, true), pod(100, 0, false))
+		beginRunning()
+
+		By("Deleting one of the deployed components out from under the AppWrapper")
+		aw := getAppWrapper(awName)
+		cs := aw.Status.ComponentStatus[0]
+		victim := &metav1.PartialObjectMetadata{TypeMeta: metav1.TypeMeta{Kind: cs.Kind, APIVersion: cs.APIVersion}}
+		victim.Name = cs.Name
+		victim.Namespace = aw.Namespace
+		Expect(k8sClient.Delete(ctx, victim)).To(Succeed())
+
+		By("Reconciling: Running -> Failed")
+		_, err := awReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: awName})
+		Expect(err).NotTo(HaveOccurred())
+
+		aw = getAppWrapper(awName)
+		Expect(aw.Status.Phase).Should(Equal(awv1beta2.AppWrapperFailed))
+		Expect(meta.IsStatusConditionTrue(aw.Status.Conditions, string(awv1beta2.Unhealthy))).Should(BeTrue())
 	})
 
 	It("Happy Path Lifecycle", func() {
@@ -404,10 +443,11 @@ var _ = Describe("AppWrapper Annotations", func() {
 
 	BeforeEach(func() {
 		awReconciler = &AppWrapperReconciler{
-			Client:   k8sClient,
-			Recorder: &events.FakeRecorder{},
-			Scheme:   k8sClient.Scheme(),
-			Config:   config.NewAppWrapperConfig(),
+			Client:    k8sClient,
+			APIReader: k8sClient,
+			Recorder:  &events.FakeRecorder{},
+			Scheme:    k8sClient.Scheme(),
+			Config:    config.NewAppWrapperConfig(),
 		}
 	})
 

--- a/internal/controller/appwrapper/fixtures_test.go
+++ b/internal/controller/appwrapper/fixtures_test.go
@@ -17,14 +17,17 @@ limitations under the License.
 package appwrapper
 
 import (
+	"context"
 	"fmt"
 	"math/rand"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -215,4 +218,19 @@ func malformedPod(milliCPU int64) awv1beta2.AppWrapperComponent {
 		DeclaredPodSets: []awv1beta2.AppWrapperPodSet{{Replicas: ptr.To(int32(1)), Path: "template"}},
 		Template:        runtime.RawExtension{Raw: jsonBytes},
 	}
+}
+
+// cacheBlindToPods simulates a controller-runtime cache that has not yet observed the
+// AppWrapper's deployed components: Get reports NotFound for the PartialObjectMetadata
+// reads that getComponentStatus performs, while every other operation is delegated to the
+// real client.  This reproduces the informer lag that used to fail AppWrappers outright.
+type cacheBlindToPods struct {
+	client.Client
+}
+
+func (c *cacheBlindToPods) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	if meta, ok := obj.(*metav1.PartialObjectMetadata); ok {
+		return apierrors.NewNotFound(schema.GroupResource{Resource: meta.Kind}, key.Name)
+	}
+	return c.Client.Get(ctx, key, obj, opts...)
 }

--- a/pkg/controller/setup.go
+++ b/pkg/controller/setup.go
@@ -44,10 +44,11 @@ func SetupControllers(mgr ctrl.Manager, awConfig *config.AppWrapperConfig) error
 	}
 
 	if err := (&appwrapper.AppWrapperReconciler{
-		Client:   mgr.GetClient(),
-		Recorder: mgr.GetEventRecorder("appwrappers"),
-		Scheme:   mgr.GetScheme(),
-		Config:   awConfig,
+		Client:    mgr.GetClient(),
+		APIReader: mgr.GetAPIReader(),
+		Recorder:  mgr.GetEventRecorder("appwrappers"),
+		Scheme:    mgr.GetScheme(),
+		Config:    awConfig,
 	}).SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("appwrapper controller: %w", err)
 	}


### PR DESCRIPTION
In the `Running` phase, `deployed != expected` is treated as an externally deleted component and fails the AppWrapper immediately — deliberately with no grace period and no retry, since an operator deleting a component will not self-correct (`internal/controller/appwrapper/appwrapper_controller.go:262`).

That verdict is drawn from `getComponentStatus`, which reads components through the cache-backed `Client`. The cache is not a sound basis for a terminal verdict: it can lag the API server, so "not in my cache yet" is indistinguishable from "deleted". Two things make the lag routine rather than exotic:

- Components are created with `r.Create` — an uncached write straight to the API server — while the check reads from the cache. The `Resuming -> Running` status patch re-reconciles within tens of milliseconds, so the read can land before the watch event for the controller's *own* write arrives.
- `SetupWithManager` watches `AppWrapper` and `Pod`, but not the component types the controller deploys. Their informers are created lazily on the first `Get`, and because there is no component watch, nothing later re-triggers reconciliation to correct a wrong reading.

This is also the only zero-tolerance path in the controller: `AdmissionGracePeriod`, `WarmupGracePeriod`, `FailureGracePeriod`, `RetryPausePeriod` and `RetryLimit` all exist and are honoured by every other failure mode.

Observed in production on a `batch/v1` Job, from the controller log interleaved with the Kubernetes audit log:

```
17:16:26.353  Resuming
17:16:26.432  jobs.create status=0        <- the Job exists from here on
17:16:26.501  Running
17:16:26.529  Running                     <- next reconcile, Running-phase cached read
17:16:26.530  MissingComponent: Only found 0 deployed components, but was expecting 1
17:16:26.555  Failed                      <- no grace period, no retry
17:16:26.591  jobs.delete status=0        <- controller deletes the Job it just created
```

The Job had existed for 98 ms when the controller declared it missing, and the same service account that created it then deleted it. A separate incident on another cluster measured 119 ms with an identical shape.

# Issue link

No pre-existing issue — this was diagnosed from production logs and is reported here in full. For context, the check being corrected was introduced for #130 ("Detect deletion of deployed resources"), whose target case is a human deleting a wrapped resource. That case is unaffected by this change.

# What changes have been made

`getComponentStatus` now takes the `client.Reader` to use, so one code path serves both a cached and an uncached pass.

In the `Running` phase, when the cached read reports `deployed != expected`, the status is re-gathered against `mgr.GetAPIReader()` and the AppWrapper is failed only if the uncached read agrees. `AppWrapperReconciler` gains an `APIReader client.Reader` field, wired from `mgr.GetAPIReader()` in `SetupControllers`; a small `apiReader()` helper falls back to the cached client if the field is unset, so a partially constructed reconciler keeps working rather than panicking.

The extra request is confined to the path that was about to fail an AppWrapper, so the steady-state read pattern is unchanged. Genuine external deletion still fails the AppWrapper with no grace period, exactly as before.

4 files, +114 / -22.

# Verification steps

**Unit / envtest** — `make test`. Two cases in `internal/controller/appwrapper/appwrapper_controller_test.go` cover both directions:

- `A stale cache must not be treated as a missing component`. A `cacheBlindToPods` double (in `fixtures_test.go`) wraps the reconciler's cached client and returns `NotFound` for the `PartialObjectMetadata` reads `getComponentStatus` performs, while `APIReader` still sees the real objects — reproducing informer lag. Asserts the AppWrapper stays `Running` with `Unhealthy=False`.
- `A genuinely deleted component still fails the AppWrapper`. Deletes a deployed component out from under the AppWrapper and asserts it still reaches `Failed` with `Unhealthy=True`.

To confirm the first test is not vacuous, neuter the fix by making `apiReader()` return `r.Client` unconditionally and re-run it: it fails with `Expected <AppWrapperPhase>: Failed to equal <AppWrapperPhase>: Running`.

**Manual, on a live cluster** — GKE 1.35.7 with Kueue 0.19, AppWrapper deployed from the v1.2.0 `install.yaml`, one component per AppWrapper (`batch/v1` Job, `sleep 10`).

Reproducing the defect requires watch *delivery* latency on a **warm** informer. Targeting cold starts does not work and is worth stating explicitly: the `batch/v1:Job` informer is created lazily on the first Running-phase `Get`, which happens *after* the controller's own `r.Create`, so the informer's initial LIST always contains that first Job. 1200 submissions across 25 deliberate controller restarts produced nothing. The vulnerable case is every *later* AppWrapper, where the informer holds a snapshot at RV=X, the new Job is created at RV=Y>X, and the Running-phase read executes before watch delivers RV=Y.

The window was widened by backing up the shared Job informer's event delivery: ~110 resident Jobs each carrying a 180KB annotation, plus a loop creating and deleting 40 more per cycle (every create and delete is a 180KB event the informer must decode and store), with a steady stream of AppWrappers submitted throughout so one is always in the `Resuming -> Running` transition.

| | Unpatched v1.2.0 | Patched |
| --- | --- | --- |
| AppWrappers submitted | 470 | 1352 (3 passes) |
| `MissingComponent` failures | 1 | 0 |
| Races entered and survived | 0 | 15 |

The 15 survivals are the substantive result — zero failures alone proves nothing, since the window is only entered under load, as the 1200 fruitless submissions above show. They are counted from a `V(2)` line the patch emits exactly when the cached read reported a component missing and the uncached read then found it present, across 15 distinct AppWrappers. The complementary line, emitted when the uncached read agrees the component is gone, fired 0 times across those 1352 submissions — so nothing was wrongly kept alive.

The controller was OOM-killed 3 times during those passes (unrelated to this change — see observation 1 below); the fix held across those restarts.

**Upgrade verification** — not applicable. No API, CRD or configuration surface changes: the diff touches only reconciler internals and the reconciler's construction in `SetupControllers`. `make manifests` produces no diff. An existing AppWrapper is unaffected on controller upgrade or rollback.

## Checks
- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests

# Two related observations, not addressed here

Happy to open separate issues if either is of interest.

1. The manager's cache is unfiltered (no `cache.ByObject` in `cmd/main.go`), so the lazily created `batch/v1:Job` informer lists and caches every Job in the cluster, and the controller's memory scales with total cluster Job count against the 128Mi limit in `install.yaml`. A selector on the AppWrapper-owned label would cut both the memory footprint and the event volume that widens the very window this PR fixes.
2. The controller serves its own admission webhook with `failurePolicy: Fail`, so while it is restarting, `kubectl apply` of an AppWrapper is rejected with `failed calling webhook "mappwrapper.kb.io"`. This makes HA or restart-based mitigation of transient controller problems costly, and it is worth knowing before recommending a restart as a workaround for anything.
